### PR TITLE
fix(shared): support satisfies version at runtime

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -12,6 +12,7 @@ declare global {
 
   var __RC_MFE_REGISTRY_CALLBACK__: any;
 
+  var __RC_MFE_SATISFY__: any;
   var __RC_MFE_USE_LOADER__: boolean;
   var ROARR: {
     write: (message: string) => void;

--- a/packages/shared/src/isSatisfied.ts
+++ b/packages/shared/src/isSatisfied.ts
@@ -6,6 +6,7 @@ export const isSatisfied = (
   options: Partial<RegistryData> | undefined,
   dependencyVersion: string
 ): options is RegistryData => {
+  // To ensure consistency, it is used for webpage or other running container  mfe info satisfies version.
   if (globalThis.__RC_MFE_SATISFY__)
     return globalThis.__RC_MFE_SATISFY__(options, dependencyVersion);
   let matchResult = false;

--- a/packages/shared/src/isSatisfied.ts
+++ b/packages/shared/src/isSatisfied.ts
@@ -6,6 +6,8 @@ export const isSatisfied = (
   options: Partial<RegistryData> | undefined,
   dependencyVersion: string
 ): options is RegistryData => {
+  if (globalThis.__RC_MFE_SATISFY__)
+    return globalThis.__RC_MFE_SATISFY__(options, dependencyVersion);
   let matchResult = false;
   try {
     matchResult = options


### PR DESCRIPTION
Since MFE information might be read by worker and other running modes before the webpage, we need a mechanism for consistent validation.