### PR TITLE
feat: support spack as plugin builder

### DIFF
--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -38,7 +38,13 @@
   "license": "MIT",
   "peerDependencies": {
     "@ringcentral/mfe-shared": "^0.1.0",
+    "@rspack/core": ">=1.0.0",
     "webpack": "^5.75.0"
+  },
+  "peerDependenciesMeta": {
+    "@rspack/core": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "webpack": "^5.75.0"

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ringcentral/mfe-builder",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "description": "A micro frontends framework for building Web applications",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/builder/src/ModuleFederationPlugin.ts
+++ b/packages/builder/src/ModuleFederationPlugin.ts
@@ -3,6 +3,12 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable prefer-destructuring */
 import { BannerPlugin, container, Compiler, DefinePlugin } from 'webpack';
+import type { Compiler } from 'webpack';
+// Support both webpack and Rspack. Set BUNDLER=rspack to use @rspack/core.
+// eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-shadow
+const { BannerPlugin, container, DefinePlugin } = (
+process.env.BUNDLER === 'rspack' ? require('@rspack/core') : require('webpack')
+) as typeof import('webpack');
 import {
   getEntryFromRegistry,
   fetchWithJsonp,


### PR DESCRIPTION
can use process.env.BUNDLER = 'rspack' to switch to rspack, default is webpack