### PR TITLE
feat(builder): opt-in federated types via @module-federation/dts-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 - **CSS isolation** - Support CSS modules CSS isolation injection for Webpack `style-loader` and so on.
 - **Debugger/Logger** - Provide meta info for Debugging/Logging.
 - **Version control** - Support custom registry for MFE remote entry version control
+- **Federated types** - Opt-in TypeScript declarations for federated modules via the `dts` option
 
 ## Installation
 
@@ -117,6 +118,82 @@ const App2 = useApp({
 
 > `webpack dev server` is not supported in multiple entry points, so you need to build and serve the worker file manually(e.g. `examples/basic/app3/dev.js`).
 > After building, all files in the `worker` directory except for `remoteEntry.js` do not need to be deployed.This means that you will have two MFE bundled files in different directories, e.g. `http://localhost:3000/remoteEntry.js` and `http://localhost:3000/worker/remoteEntry.js`. The name of the `worker` directory config is hardcode here.
+
+## Federated types
+
+`@ringcentral/mfe-builder` can emit and consume TypeScript declarations for federated modules using the standard Module Federation type mechanism: a producer publishes `@mf-types.zip` / `@mf-types.d.ts` next to its `remoteEntry.js`, and a consumer gets typed remotes. It is opt-in via the `dts` option and off by default — when `dts` is unset the build output is unchanged and no extra dependency is pulled in.
+
+Types are handled by [`@module-federation/dts-plugin`](https://www.npmjs.com/package/@module-federation/dts-plugin), an **optional peer dependency**. Install it in any project that sets `dts`:
+
+```sh
+yarn add -D @module-federation/dts-plugin
+# or
+npm install -D @module-federation/dts-plugin
+```
+
+> `@module-federation/dts-plugin` requires **Node >= 20.18.1**. Projects that do not use `dts` keep the builder's Node >= 16 support and pull nothing extra.
+
+### Producing types
+
+Enable `generateTypes` in the remote's `site.config`:
+
+```js
+module.exports = {
+  name: '@example/app2',
+  exposes: {
+    './src/bootstrap': './src/bootstrap',
+  },
+  dts: {
+    generateTypes: {
+      // A tsconfig that narrows `rootDir` to the exposed surface keeps the
+      // archive to the public API instead of the whole workspace.
+      tsConfigPath: './tsconfig.types.json',
+    },
+  },
+};
+```
+
+The archive is emitted at the output root, next to `remoteEntry.js`, so consumers can locate it. If the container `filename` is nested, set `generateTypes.outputDir` to the same directory to keep the archive co-located with the remote entry.
+
+> The exposed declarations must use relative or package-resolvable imports only. `@module-federation/dts-plugin` does not rewrite `tsconfig` path-alias imports in the emitted declarations ([module-federation/core#3363](https://github.com/module-federation/core/issues/3363)), so a public entry importing through a path alias (for example `@internal/model`) is unresolvable for consumers.
+
+### Consuming types
+
+Enable `consumeTypes` (or simply set `dts` when the site declares `dependencies`):
+
+```js
+module.exports = {
+  name: '@example/app1',
+  dependencies: {
+    '@example/app2': 'http://localhost:3002/remoteEntry.js',
+  },
+  dts: {
+    consumeTypes: true,
+  },
+};
+```
+
+The type-archive URL for each remote is derived from its `dependencies` entry (the same base plus `/@mf-types.zip`). When the site sets a `registry` with `registryAutoFetch: true` (and the default `fetch` registry type), the URLs are instead resolved from the registry at build time so the types match the version the runtime resolves; on any registry miss or failure the derived URL is used.
+
+Add the fetched types to the consumer's `tsconfig.json` so the editor and compiler pick them up:
+
+```json
+{
+  "compilerOptions": {
+    "paths": {
+      "*": ["./@mf-types/*"]
+    }
+  }
+}
+```
+
+Remote types update out of band from the consumer's lockfile; delete the local `./@mf-types` directory to force a refresh.
+
+### Limitations
+
+- No dev-time hot type reload — `dev` is forced off; types are generated and consumed at build time.
+- `tsconfig` path-alias imports in a public entry are not rewritten in the emitted declarations ([module-federation/core#3363](https://github.com/module-federation/core/issues/3363)); use relative or package-resolvable imports.
+- Build-time registry resolution needs the `registry` endpoint reachable from the build environment; otherwise the static derivation from `dependencies` is used.
 
 ## Contribution
 

--- a/README.md
+++ b/README.md
@@ -121,17 +121,11 @@ const App2 = useApp({
 
 ## Federated types
 
-`@ringcentral/mfe-builder` can emit and consume TypeScript declarations for federated modules using the standard Module Federation type mechanism: a producer publishes `@mf-types.zip` / `@mf-types.d.ts` next to its `remoteEntry.js`, and a consumer gets typed remotes. It is opt-in via the `dts` option and off by default — when `dts` is unset the build output is unchanged and no extra dependency is pulled in.
+`@ringcentral/mfe-builder` can emit and consume TypeScript declarations for federated modules using the standard Module Federation type mechanism: a producer publishes `@mf-types.zip` / `@mf-types.d.ts` next to its `remoteEntry.js`, and a consumer gets typed remotes. It is opt-in via the `dts` option and off by default — when `dts` is unset the build output is unchanged.
 
-Types are handled by [`@module-federation/dts-plugin`](https://www.npmjs.com/package/@module-federation/dts-plugin), an **optional peer dependency**. Install it in any project that sets `dts`:
+Types are handled by [`@module-federation/dts-plugin`](https://www.npmjs.com/package/@module-federation/dts-plugin), which ships as an **optional dependency** of `@ringcentral/mfe-builder` — it is installed automatically, so no manual step is needed to use `dts`.
 
-```sh
-yarn add -D @module-federation/dts-plugin
-# or
-npm install -D @module-federation/dts-plugin
-```
-
-> `@module-federation/dts-plugin` requires **Node >= 20.18.1**. Projects that do not use `dts` keep the builder's Node >= 16 support and pull nothing extra.
+> `@module-federation/dts-plugin` requires **Node >= 20.18.1**. On older Node it is skipped at install time and the `dts` option is unavailable — enabling `dts` then fails with a clear error. The builder itself keeps its Node >= 16 support for projects that do not use `dts`.
 
 ### Producing types
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ Add the fetched types to the consumer's `tsconfig.json` so the editor and compil
 
 Remote types update out of band from the consumer's lockfile; delete the local `./@mf-types` directory to force a refresh.
 
+> Remote types are fetched during the webpack/rspack build (build time — there is no dev hot-reload of types), so `./@mf-types` does not exist until the bundler has run at least once. Run the build before `tsc` or your editor can resolve the remote types, and in CI sequence the bundler build ahead of the type-check step.
+
 ### Limitations
 
 - No dev-time hot type reload — `dev` is forced off; types are generated and consumed at build time.

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -37,16 +37,21 @@
   "author": "RingCentral",
   "license": "MIT",
   "peerDependencies": {
+    "@module-federation/dts-plugin": "^2.8.0",
     "@ringcentral/mfe-shared": "^0.1.0",
     "@rspack/core": ">=1.0.0",
     "webpack": "^5.75.0"
   },
   "peerDependenciesMeta": {
+    "@module-federation/dts-plugin": {
+      "optional": true
+    },
     "@rspack/core": {
       "optional": true
     }
   },
   "devDependencies": {
+    "@module-federation/dts-plugin": "2.8.0",
     "@rspack/core": "^1.0.0",
     "webpack": "^5.75.0"
   },

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -37,25 +37,23 @@
   "author": "RingCentral",
   "license": "MIT",
   "peerDependencies": {
-    "@module-federation/dts-plugin": "^2.8.0",
     "@ringcentral/mfe-shared": "^0.1.0",
     "@rspack/core": ">=1.0.0",
     "webpack": "^5.75.0"
   },
   "peerDependenciesMeta": {
-    "@module-federation/dts-plugin": {
-      "optional": true
-    },
     "@rspack/core": {
       "optional": true
     }
   },
   "devDependencies": {
-    "@module-federation/dts-plugin": "2.8.0",
     "@rspack/core": "^1.0.0",
     "webpack": "^5.75.0"
   },
   "dependencies": {
     "yargs": "17.6.2"
+  },
+  "optionalDependencies": {
+    "@module-federation/dts-plugin": "2.8.0"
   }
 }

--- a/packages/builder/src/ModuleFederationPlugin.ts
+++ b/packages/builder/src/ModuleFederationPlugin.ts
@@ -161,13 +161,14 @@ class ModuleFederationPlugin extends container.ModuleFederationPlugin {
   }
 
   /**
-   * Apply the optional `@module-federation/dts-plugin` when `dts` is enabled.
+   * Apply `@module-federation/dts-plugin` when `dts` is enabled.
    *
-   * Loaded lazily (never at module top-level): the peer pulls a heavy dependency
-   * subtree and requires Node >=20.18.1, so an eager import would break loading
-   * the builder for non-adopters. The same package covers webpack and Rspack, so
-   * no `BUNDLER` switch is needed. `DtsPlugin` reads its config from
-   * `options.dts`; `addRuntimePlugins()` is not called (no enhanced runtime).
+   * It ships as an optional dependency and is required lazily (never at module
+   * top-level): it pulls a heavy dependency subtree and needs Node >=20.18.1, so
+   * an eager import would crash the builder wherever the platform skipped it. The
+   * same package covers webpack and Rspack, so no `BUNDLER` switch is needed.
+   * `DtsPlugin` reads its config from `options.dts`; `addRuntimePlugins()` is not
+   * called (no enhanced runtime).
    */
   private applyDtsPlugin(compiler: Compiler) {
     let dtsPlugin: typeof import('@module-federation/dts-plugin');
@@ -177,10 +178,10 @@ class ModuleFederationPlugin extends container.ModuleFederationPlugin {
         require('@module-federation/dts-plugin') as typeof import('@module-federation/dts-plugin');
     } catch (error) {
       const err = error as NodeJS.ErrnoException | undefined;
-      // Only the peer itself being absent is the opt-in error. Match the
-      // specifier form (not a bare substring): Node's MODULE_NOT_FOUND message
-      // also lists the failing module's path under "Require stack:", so a broken
-      // transitive dependency would otherwise be misreported as "not installed".
+      // Only the optional dependency itself being absent is the opt-in error.
+      // Match the specifier form (not a bare substring): Node's MODULE_NOT_FOUND
+      // message also lists the failing module's path under "Require stack:", so a
+      // broken transitive dependency would otherwise be misreported as absent.
       if (
         err?.code === 'MODULE_NOT_FOUND' &&
         err.message.includes(
@@ -188,7 +189,7 @@ class ModuleFederationPlugin extends container.ModuleFederationPlugin {
         )
       ) {
         throw new Error(
-          `[MFE] 'dts' is enabled but the optional peer '@module-federation/dts-plugin' is not installed. Install it to opt in to federated types (requires Node >=20.18.1), e.g. \`yarn add -D @module-federation/dts-plugin\` or \`npm i -D @module-federation/dts-plugin\`.`
+          `[MFE] federated types require '@module-federation/dts-plugin', which ships as an optional dependency but could not be loaded (it requires Node >=20.18.1). Upgrade Node or install it manually to use \`dts\`.`
         );
       }
       throw error;

--- a/packages/builder/src/ModuleFederationPlugin.ts
+++ b/packages/builder/src/ModuleFederationPlugin.ts
@@ -12,10 +12,15 @@ import {
   identifier,
   identifierContainer,
   SiteConfig,
+  PluginDtsOptions,
   isSatisfied,
   satisfiesVersion,
 } from '@ringcentral/mfe-shared';
-import { getModuleFederationConfig, getSiteConfig } from './getConfig';
+import {
+  getDtsPluginOptions,
+  getModuleFederationConfig,
+  getSiteConfig,
+} from './getConfig';
 import { getEnv } from './getEnv';
 import { makeBannerScript } from './make';
 
@@ -41,7 +46,7 @@ export const getBannerScript = ({
   identifierContainer: string;
   mfeConfig: Pick<
     SiteConfig,
-    Exclude<keyof SiteConfig, 'optimization' | 'shared'>
+    Exclude<keyof SiteConfig, 'optimization' | 'shared' | 'dts'>
   >;
   identifier: string;
   maxRetries: number;
@@ -82,6 +87,14 @@ class ModuleFederationPlugin extends container.ModuleFederationPlugin {
 
   definePlugin: InstanceType<typeof DefinePlugin>;
 
+  // Native federation options handed to `super()`, reused when applying the
+  // optional DtsPlugin. Never contains `dts`/`dev`.
+  private federationOptions: ModuleFederationPluginOptions;
+
+  // Resolved Module Federation type options; `undefined` when `dts` is unset,
+  // in which case nothing DTS-shaped is applied and output is byte-identical.
+  private dtsOptions?: PluginDtsOptions;
+
   constructor(
     siteExtraConfig?: SiteOverridableConfig,
     externalOptions?: ModuleFederationPluginOptions
@@ -89,13 +102,21 @@ class ModuleFederationPlugin extends container.ModuleFederationPlugin {
     const siteConfig = getSiteConfig({
       overrides: siteExtraConfig,
     });
-    const moduleFederationConfig = getModuleFederationConfig(siteConfig);
+    // Separate the opt-in `dts` capability from the native federation config
+    // BEFORE building super() options: webpack's ModuleFederationPlugin
+    // constructor rejects unknown keys, and the banner must not serialize it.
+    const { dts, ...builderConfig } = siteConfig;
+    const moduleFederationConfig = getModuleFederationConfig(builderConfig);
     const options = {
       ...moduleFederationConfig,
       ...externalOptions,
     };
     super(options);
-    const { shared, optimization, ...mfeConfig } = siteConfig;
+    this.federationOptions = options;
+    // Resolve from the full siteConfig (needs `dependencies`); applied lazily
+    // in apply() only when `dts` was set.
+    this.dtsOptions = getDtsPluginOptions(siteConfig);
+    const { shared, optimization, ...mfeConfig } = builderConfig;
     const maxRetries = siteConfig.maxRetries ?? 1;
     const retryDelay = siteConfig.retryDelay ?? 1000;
     const injectMeta = optimization?.injectMeta;
@@ -129,6 +150,50 @@ class ModuleFederationPlugin extends container.ModuleFederationPlugin {
     this.definePlugin.apply.call(this.definePlugin, compiler);
     if (isSPAbuild) return;
     super.apply.call(this, compiler);
+    // Federated types live in the non-SPA path, after native federation.
+    if (this.dtsOptions) this.applyDtsPlugin(compiler);
+  }
+
+  /**
+   * Apply the optional `@module-federation/dts-plugin` when `dts` is enabled.
+   *
+   * The peer is loaded lazily here (never at module top-level): it pulls a
+   * heavy dependency subtree and requires Node >=20.18.1, so eager loading
+   * would break the builder for the majority of consumers that never opt in.
+   * The same package covers webpack and Rspack, so — unlike `BannerPlugin` /
+   * `DefinePlugin` above — no `BUNDLER` switch is needed.
+   *
+   * `DtsPlugin` reads its configuration from `options.dts`, so it receives the
+   * native federation options augmented with the resolved `dts` block. Build
+   * time only: `addRuntimePlugins()` is intentionally not called (this builder
+   * ships no enhanced runtime).
+   */
+  private applyDtsPlugin(compiler: Compiler) {
+    let dtsPlugin: typeof import('@module-federation/dts-plugin');
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      dtsPlugin =
+        require('@module-federation/dts-plugin') as typeof import('@module-federation/dts-plugin');
+    } catch (error) {
+      if (
+        (error as NodeJS.ErrnoException | undefined)?.code ===
+        'MODULE_NOT_FOUND'
+      ) {
+        throw new Error(
+          `[MFE] 'dts' is enabled but the optional peer '@module-federation/dts-plugin' is not installed. Install it to opt in to federated types (requires Node >=20.18.1), e.g. \`yarn add -D @module-federation/dts-plugin\`.`
+        );
+      }
+      throw error;
+    }
+    // Future generality seam: an `onTypesEmitted(urls)` hook could publish the
+    // emitted type-archive URLs (e.g. into a runtime registry) without the core
+    // feature knowing about any specific consumer. Deferred in v1.
+    new dtsPlugin.DtsPlugin({
+      ...this.federationOptions,
+      // Dev-time hot type reload is unsupported in v1; force it off.
+      dev: false,
+      dts: this.dtsOptions,
+    }).apply(compiler);
   }
 }
 

--- a/packages/builder/src/ModuleFederationPlugin.ts
+++ b/packages/builder/src/ModuleFederationPlugin.ts
@@ -177,11 +177,15 @@ class ModuleFederationPlugin extends container.ModuleFederationPlugin {
         require('@module-federation/dts-plugin') as typeof import('@module-federation/dts-plugin');
     } catch (error) {
       const err = error as NodeJS.ErrnoException | undefined;
-      // Only the peer itself being absent is the opt-in error; a broken
-      // transitive dependency must surface as its own failure.
+      // Only the peer itself being absent is the opt-in error. Match the
+      // specifier form (not a bare substring): Node's MODULE_NOT_FOUND message
+      // also lists the failing module's path under "Require stack:", so a broken
+      // transitive dependency would otherwise be misreported as "not installed".
       if (
         err?.code === 'MODULE_NOT_FOUND' &&
-        err.message.includes('@module-federation/dts-plugin')
+        err.message.includes(
+          "Cannot find module '@module-federation/dts-plugin'"
+        )
       ) {
         throw new Error(
           `[MFE] 'dts' is enabled but the optional peer '@module-federation/dts-plugin' is not installed. Install it to opt in to federated types (requires Node >=20.18.1), e.g. \`yarn add -D @module-federation/dts-plugin\` or \`npm i -D @module-federation/dts-plugin\`.`

--- a/packages/builder/src/ModuleFederationPlugin.ts
+++ b/packages/builder/src/ModuleFederationPlugin.ts
@@ -102,10 +102,16 @@ class ModuleFederationPlugin extends container.ModuleFederationPlugin {
     const siteConfig = getSiteConfig({
       overrides: siteExtraConfig,
     });
-    // Separate the opt-in `dts` capability from the native federation config
-    // BEFORE building super() options: webpack's ModuleFederationPlugin
-    // constructor rejects unknown keys, and the banner must not serialize it.
-    const { dts, ...builderConfig } = siteConfig;
+    // Strip non-native keys before building super() options: the native
+    // container rejects unknown keys and the banner must not serialize them.
+    // site.config is arbitrary JS, so drop enhanced-only keys at runtime too.
+    const { dts, dev, runtimePlugins, ...builderConfig } =
+      siteConfig as SiteConfig & { dev?: unknown; runtimePlugins?: unknown };
+    if (__DEV__ && (dev !== undefined || runtimePlugins !== undefined)) {
+      console.warn(
+        `[MFE] 'dev'/'runtimePlugins' are not supported by this builder and are ignored.`
+      );
+    }
     const moduleFederationConfig = getModuleFederationConfig(builderConfig);
     const options = {
       ...moduleFederationConfig,
@@ -157,16 +163,11 @@ class ModuleFederationPlugin extends container.ModuleFederationPlugin {
   /**
    * Apply the optional `@module-federation/dts-plugin` when `dts` is enabled.
    *
-   * The peer is loaded lazily here (never at module top-level): it pulls a
-   * heavy dependency subtree and requires Node >=20.18.1, so eager loading
-   * would break the builder for the majority of consumers that never opt in.
-   * The same package covers webpack and Rspack, so — unlike `BannerPlugin` /
-   * `DefinePlugin` above — no `BUNDLER` switch is needed.
-   *
-   * `DtsPlugin` reads its configuration from `options.dts`, so it receives the
-   * native federation options augmented with the resolved `dts` block. Build
-   * time only: `addRuntimePlugins()` is intentionally not called (this builder
-   * ships no enhanced runtime).
+   * Loaded lazily (never at module top-level): the peer pulls a heavy dependency
+   * subtree and requires Node >=20.18.1, so an eager import would break loading
+   * the builder for non-adopters. The same package covers webpack and Rspack, so
+   * no `BUNDLER` switch is needed. `DtsPlugin` reads its config from
+   * `options.dts`; `addRuntimePlugins()` is not called (no enhanced runtime).
    */
   private applyDtsPlugin(compiler: Compiler) {
     let dtsPlugin: typeof import('@module-federation/dts-plugin');
@@ -175,22 +176,22 @@ class ModuleFederationPlugin extends container.ModuleFederationPlugin {
       dtsPlugin =
         require('@module-federation/dts-plugin') as typeof import('@module-federation/dts-plugin');
     } catch (error) {
+      const err = error as NodeJS.ErrnoException | undefined;
+      // Only the peer itself being absent is the opt-in error; a broken
+      // transitive dependency must surface as its own failure.
       if (
-        (error as NodeJS.ErrnoException | undefined)?.code ===
-        'MODULE_NOT_FOUND'
+        err?.code === 'MODULE_NOT_FOUND' &&
+        err.message.includes('@module-federation/dts-plugin')
       ) {
         throw new Error(
-          `[MFE] 'dts' is enabled but the optional peer '@module-federation/dts-plugin' is not installed. Install it to opt in to federated types (requires Node >=20.18.1), e.g. \`yarn add -D @module-federation/dts-plugin\`.`
+          `[MFE] 'dts' is enabled but the optional peer '@module-federation/dts-plugin' is not installed. Install it to opt in to federated types (requires Node >=20.18.1), e.g. \`yarn add -D @module-federation/dts-plugin\` or \`npm i -D @module-federation/dts-plugin\`.`
         );
       }
       throw error;
     }
-    // Future generality seam: an `onTypesEmitted(urls)` hook could publish the
-    // emitted type-archive URLs (e.g. into a runtime registry) without the core
-    // feature knowing about any specific consumer. Deferred in v1.
     new dtsPlugin.DtsPlugin({
       ...this.federationOptions,
-      // Dev-time hot type reload is unsupported in v1; force it off.
+      // No dev-time type server; force `dev` off.
       dev: false,
       dts: this.dtsOptions,
     }).apply(compiler);

--- a/packages/builder/src/getConfig.ts
+++ b/packages/builder/src/getConfig.ts
@@ -15,7 +15,12 @@ import type {
   RemoteTypeUrls,
   RegistryResponse,
 } from '@ringcentral/mfe-shared';
-import { getGlobal, identifierContainer } from '@ringcentral/mfe-shared';
+import {
+  getGlobal,
+  identifierContainer,
+  isSatisfied,
+  satisfiesVersion,
+} from '@ringcentral/mfe-shared';
 import { getEnv } from './getEnv';
 import { makeRemoteScript } from './make';
 
@@ -25,6 +30,10 @@ const DEFAULT_REMOTE_ENTRY = 'remoteEntry.js';
 // remote entry by `@module-federation/dts-plugin`.
 const MF_TYPES_ZIP = '@mf-types.zip';
 const MF_TYPES_API = '@mf-types.d.ts';
+
+// Registry-lookup timeout (ms) so a hanging registry cannot stall the build;
+// overridable via `consumeTypes.timeout`. On timeout we fall back to static.
+const DEFAULT_REGISTRY_TIMEOUT = 5000;
 
 export const getSiteConfig = ({ overrides = {} }: Options = {}): SiteConfig => {
   // TODO: implement more config options
@@ -201,26 +210,40 @@ const mergeRemoteTypeUrls = (
 };
 
 /**
- * A configured `registry` can be queried at build time (jsonp is browser-only,
- * so `fetch` only) to resolve the live entry a remote would load, closing the
- * version skew a purely static derivation can carry.
+ * Whether the build-time registry resolver applies. It mirrors the runtime: the
+ * runtime only queries the registry when `registryAutoFetch` is on and the
+ * registry type is `fetch` (jsonp is browser-only), so the resolver queries
+ * only under the same conditions — fidelity over reach.
  */
 const canUseRegistryResolver = (siteConfig: SiteConfig): boolean =>
   typeof siteConfig.registry === 'string' &&
   siteConfig.registry !== '*' &&
-  siteConfig.registryType !== 'jsonp' &&
+  (siteConfig.registryType ?? 'fetch') === 'fetch' &&
+  siteConfig.registryAutoFetch === true &&
   typeof fetch === 'function';
+
+/**
+ * A time-bounded `AbortSignal` when the runtime provides `AbortSignal.timeout`
+ * (Node >=17.3; dts requires >=20.18.1), else `undefined` (unbounded fetch).
+ */
+const timeoutSignal = (ms: number): AbortSignal | undefined => {
+  const ctor = AbortSignal as { timeout?: (ms: number) => AbortSignal };
+  return typeof ctor.timeout === 'function' ? ctor.timeout(ms) : undefined;
+};
 
 /**
  * Build an async `remoteTypeUrls` resolver (Module Federation's supported
  * function form) that, per dependency, queries the `registry` with the same
- * shape the runtime uses and derives the type-archive URL from the resolved
- * entry. Any failure falls back to the static-derived URL, so type resolution
- * never fails the build.
+ * shape and acceptance rule the runtime uses (`getEntryFromRegistry`): the query
+ * carries the consumer's version, and the resolved entry is used only when it
+ * satisfies the dependency version (honoring `forcedVersion`). The type-archive
+ * URL is derived from that entry. Any miss or failure falls back to the
+ * static-derived URL, so type resolution never fails the build.
  */
 const createRegistryResolver = (
   siteConfig: SiteConfig,
-  derived: RemoteTypeUrls
+  derived: RemoteTypeUrls,
+  timeout: number
 ): (() => Promise<RemoteTypeUrls>) => {
   const registry = siteConfig.registry as string;
   const { dependencies, name: main, version: mainVersion } = siteConfig;
@@ -236,15 +259,22 @@ const createRegistryResolver = (
             mainVersion: mainVersion ?? '*',
             _: Date.now().toString(),
           };
-          const version = typeof value === 'object' ? value.version : undefined;
-          if (version) query.version = version;
+          // The runtime query carries the consumer's version, not the remote's.
+          if (mainVersion) query.version = mainVersion;
           const response = await fetch(
-            `${registry}?${new URLSearchParams(query)}`
+            `${registry}?${new URLSearchParams(query)}`,
+            { signal: timeoutSignal(timeout) }
           );
           const data = (await response.json()) as RegistryResponse;
-          const entry = data?.[dependency]?.entry;
-          const base =
-            typeof entry === 'string' ? deriveTypeBase(entry) : undefined;
+          const remoteData = data?.[dependency];
+          const dependencyVersion =
+            typeof value === 'object' ? value.dependencyVersion ?? '*' : '*';
+          // Accept the registry answer only when it satisfies the dependency
+          // version (as the runtime does); otherwise keep the static URL.
+          if (!isSatisfied(satisfiesVersion, remoteData, dependencyVersion)) {
+            return [dependency, fallback] as const;
+          }
+          const base = deriveTypeBase(remoteData.entry);
           if (!base) return [dependency, fallback] as const;
           return [
             dependency,
@@ -275,14 +305,15 @@ const createRegistryResolver = (
 const resolveRemoteTypeUrls = (
   siteConfig: SiteConfig,
   derived: RemoteTypeUrls,
-  userRemoteTypeUrls: DtsConsumeTypesOptions['remoteTypeUrls']
+  userRemoteTypeUrls: DtsConsumeTypesOptions['remoteTypeUrls'],
+  timeout: number
 ): DtsConsumeTypesOptions['remoteTypeUrls'] => {
   if (typeof userRemoteTypeUrls === 'function') return userRemoteTypeUrls;
   if (userRemoteTypeUrls && Object.keys(userRemoteTypeUrls).length > 0) {
     return mergeRemoteTypeUrls(derived, userRemoteTypeUrls);
   }
   if (canUseRegistryResolver(siteConfig)) {
-    return createRegistryResolver(siteConfig, derived);
+    return createRegistryResolver(siteConfig, derived, timeout);
   }
   return derived;
 };
@@ -319,6 +350,7 @@ export const getDtsPluginOptions = (
     const userConsume: DtsConsumeTypesOptions =
       typeof resolved.consumeTypes === 'object' ? resolved.consumeTypes : {};
     const derived = deriveRemoteTypeUrls(dependencies);
+    const timeout = userConsume.timeout ?? DEFAULT_REGISTRY_TIMEOUT;
     // Turn consuming on only when the user opted in or a remote was discovered.
     if (
       resolved.consumeTypes !== undefined ||
@@ -331,7 +363,8 @@ export const getDtsPluginOptions = (
         remoteTypeUrls: resolveRemoteTypeUrls(
           siteConfig,
           derived,
-          userConsume.remoteTypeUrls
+          userConsume.remoteTypeUrls,
+          timeout
         ),
       };
     }

--- a/packages/builder/src/getConfig.ts
+++ b/packages/builder/src/getConfig.ts
@@ -268,7 +268,9 @@ const createRegistryResolver = (
           const data = (await response.json()) as RegistryResponse;
           const remoteData = data?.[dependency];
           const dependencyVersion =
-            typeof value === 'object' ? value.dependencyVersion ?? '*' : '*';
+            typeof value === 'object'
+              ? value.dependencyVersion ?? value.version ?? '*'
+              : '*';
           // Accept the registry answer only when it satisfies the dependency
           // version (as the runtime does); otherwise keep the static URL.
           if (!isSatisfied(satisfiesVersion, remoteData, dependencyVersion)) {

--- a/packages/builder/src/getConfig.ts
+++ b/packages/builder/src/getConfig.ts
@@ -274,6 +274,11 @@ const createRegistryResolver = (
           // Accept the registry answer only when it satisfies the dependency
           // version (as the runtime does); otherwise keep the static URL.
           if (!isSatisfied(satisfiesVersion, remoteData, dependencyVersion)) {
+            // Surface the divergence: a build-vs-runtime type mismatch would
+            // otherwise be hidden by the static fallback.
+            console.warn(
+              `[MFE] federated types: registry entry for '${dependency}' did not satisfy the required version, using the static type URL`
+            );
             return [dependency, fallback] as const;
           }
           const base = deriveTypeBase(remoteData.entry);
@@ -287,6 +292,11 @@ const createRegistryResolver = (
             },
           ] as const;
         } catch {
+          // Surface the failure: a silent fallback hides a registry outage that
+          // may leave the consumer's types stale relative to the runtime.
+          console.warn(
+            `[MFE] federated types: registry lookup failed for '${dependency}', using the static type URL`
+          );
           return [dependency, fallback] as const;
         }
       })

--- a/packages/builder/src/getConfig.ts
+++ b/packages/builder/src/getConfig.ts
@@ -9,12 +9,20 @@ import type {
   ModuleFederationConfig,
   SiteConfigFile,
   ModuleFederationPluginOptions,
+  PluginDtsOptions,
+  DtsConsumeTypesOptions,
+  RemoteTypeUrl,
 } from '@ringcentral/mfe-shared';
 import { getGlobal, identifierContainer } from '@ringcentral/mfe-shared';
 import { getEnv } from './getEnv';
 import { makeRemoteScript } from './make';
 
 const DEFAULT_REMOTE_ENTRY = 'remoteEntry.js';
+
+// Conventional Module Federation type-archive filenames emitted next to the
+// remote entry by `@module-federation/dts-plugin`.
+const MF_TYPES_ZIP = '@mf-types.zip';
+const MF_TYPES_API = '@mf-types.d.ts';
 
 export const getSiteConfig = ({ overrides = {} }: Options = {}): SiteConfig => {
   // TODO: implement more config options
@@ -126,4 +134,99 @@ export const getModuleFederationConfig = (
     remoteType: 'script',
     ...restConfig,
   };
+};
+
+/**
+ * Strip the final path segment (the remote entry file, e.g. `remoteEntry.js`)
+ * from an entry URL so sibling assets can be addressed at the same base.
+ */
+const stripEntryFilename = (entry: string): string => {
+  const lastSlash = entry.lastIndexOf('/');
+  return lastSlash === -1 ? entry : entry.slice(0, lastSlash);
+};
+
+/**
+ * Derive the standard remote type-archive locations for every dependency that
+ * declares a string `entry` URL. Discovery is fully static and build-time: the
+ * archive lives next to `remoteEntry.js`, so we reuse each dependency's entry
+ * base. Promise-style remotes have no inferable URL, so this explicit
+ * derivation (including the required `alias`) is the authoritative discovery.
+ */
+const deriveRemoteTypeUrls = (
+  dependencies: SiteConfig['dependencies']
+): Record<string, RemoteTypeUrl> => {
+  const remoteTypeUrls: Record<string, RemoteTypeUrl> = {};
+  Object.entries(dependencies ?? {}).forEach(([name, value]) => {
+    const entry = typeof value === 'string' ? value : value?.entry;
+    if (typeof entry !== 'string') return;
+    const base = stripEntryFilename(entry);
+    remoteTypeUrls[name] = {
+      alias: name,
+      zip: `${base}/${MF_TYPES_ZIP}`,
+      api: `${base}/${MF_TYPES_API}`,
+    };
+  });
+  return remoteTypeUrls;
+};
+
+/**
+ * Resolve the Module Federation `dts` options for the builder from the opt-in
+ * `siteConfig.dts`. Returns `undefined` when `dts` is unset so that nothing
+ * DTS-shaped is applied and the output stays byte-identical.
+ *
+ * - Producer: user `generateTypes` options (`tsConfigPath`, `outputDir`,
+ *   `additionalFilesToCompile`, ...) pass through untouched. We set no default
+ *   `outputDir`: dts-plugin emits `@mf-types.zip` / `@mf-types.d.ts` at the
+ *   compiler output root (next to a default `remoteEntry.js`, via the default
+ *   `typesFolder` of `@mf-types`), which is exactly the location the consumer
+ *   derivation below targets. For a nested `filename`, set `outputDir` to keep
+ *   the archive co-located with the remote entry. Note: dts-plugin does not
+ *   rewrite tsconfig path-alias imports in the emitted declarations, so a
+ *   curated public entry must use only relative or package-resolvable imports.
+ * - Consumer: derive `consumeTypes.remoteTypeUrls` from `dependencies`; a
+ *   user-supplied entry always wins (a user-supplied function resolver is left
+ *   untouched). Default `consumeTypes.typesOnBuild` to `true` when consuming is
+ *   on so production builds actually fetch the types.
+ *
+ * Note: dev-time hot type reload is unsupported in v1; the plugin forces the
+ * top-level `dev` option off when handing these options to dts-plugin.
+ */
+export const getDtsPluginOptions = (
+  siteConfig: SiteConfig
+): PluginDtsOptions | undefined => {
+  const { dts, dependencies } = siteConfig;
+  if (!dts) return undefined;
+
+  const resolved: PluginDtsOptions = { ...dts };
+
+  // Skip consumer wiring entirely when the user explicitly opted out.
+  if (resolved.consumeTypes !== false) {
+    const userConsume: DtsConsumeTypesOptions =
+      typeof resolved.consumeTypes === 'object' ? resolved.consumeTypes : {};
+    const userRemoteTypeUrls = userConsume.remoteTypeUrls;
+    // A user function resolver takes full control; skip static derivation.
+    const derived =
+      typeof userRemoteTypeUrls === 'function'
+        ? undefined
+        : deriveRemoteTypeUrls(dependencies);
+    const hasDiscovery = !!derived && Object.keys(derived).length > 0;
+    // Turn consuming on only when the user opted in or a remote was discovered.
+    if (resolved.consumeTypes !== undefined || hasDiscovery) {
+      resolved.consumeTypes = {
+        // Production consumption needs the build-time fetch; MF skips it otherwise.
+        typesOnBuild: true,
+        ...userConsume,
+        remoteTypeUrls:
+          typeof userRemoteTypeUrls === 'function'
+            ? userRemoteTypeUrls
+            : {
+                ...derived,
+                // A user-supplied entry always wins over the derived one.
+                ...userRemoteTypeUrls,
+              },
+      };
+    }
+  }
+
+  return resolved;
 };

--- a/packages/builder/src/getConfig.ts
+++ b/packages/builder/src/getConfig.ts
@@ -12,6 +12,8 @@ import type {
   PluginDtsOptions,
   DtsConsumeTypesOptions,
   RemoteTypeUrl,
+  RemoteTypeUrls,
+  RegistryResponse,
 } from '@ringcentral/mfe-shared';
 import { getGlobal, identifierContainer } from '@ringcentral/mfe-shared';
 import { getEnv } from './getEnv';
@@ -84,6 +86,7 @@ export const getModuleFederationConfig = (
     optimization,
     prefix,
     projectRoot,
+    dts,
     ...restConfig
   } = siteConfig;
   const remotes: ModuleFederationPluginOptions['remotes'] = {};
@@ -137,29 +140,41 @@ export const getModuleFederationConfig = (
 };
 
 /**
- * Strip the final path segment (the remote entry file, e.g. `remoteEntry.js`)
- * from an entry URL so sibling assets can be addressed at the same base.
+ * Derive the type-archive base for an entry URL: drop the query/hash and the
+ * final path segment (the remote entry file, e.g. `remoteEntry.js`) so sibling
+ * assets share the base. Returns `undefined` for an unparsable entry.
  */
-const stripEntryFilename = (entry: string): string => {
-  const lastSlash = entry.lastIndexOf('/');
-  return lastSlash === -1 ? entry : entry.slice(0, lastSlash);
+const deriveTypeBase = (entry: string): string | undefined => {
+  try {
+    const url = new URL(entry);
+    const dir = url.pathname.slice(0, url.pathname.lastIndexOf('/'));
+    return `${url.origin}${dir}`;
+  } catch {
+    if (__DEV__) {
+      console.warn(
+        `[MFE] Skipping remote type URL for unparsable entry: ${entry}`
+      );
+    }
+    return undefined;
+  }
 };
 
 /**
- * Derive the standard remote type-archive locations for every dependency that
- * declares a string `entry` URL. Discovery is fully static and build-time: the
- * archive lives next to `remoteEntry.js`, so we reuse each dependency's entry
- * base. Promise-style remotes have no inferable URL, so this explicit
- * derivation (including the required `alias`) is the authoritative discovery.
+ * Derive the standard remote type-archive locations for every dependency with a
+ * parseable string `entry`. Static, build-time discovery: the archive lives
+ * next to `remoteEntry.js`, so we reuse each entry's base. Promise-style remotes
+ * expose no inferable URL, so this explicit derivation (incl. `alias`) is the
+ * authoritative discovery. Entries that don't parse are skipped.
  */
 const deriveRemoteTypeUrls = (
   dependencies: SiteConfig['dependencies']
-): Record<string, RemoteTypeUrl> => {
-  const remoteTypeUrls: Record<string, RemoteTypeUrl> = {};
+): RemoteTypeUrls => {
+  const remoteTypeUrls: RemoteTypeUrls = {};
   Object.entries(dependencies ?? {}).forEach(([name, value]) => {
     const entry = typeof value === 'string' ? value : value?.entry;
     if (typeof entry !== 'string') return;
-    const base = stripEntryFilename(entry);
+    const base = deriveTypeBase(entry);
+    if (!base) return;
     remoteTypeUrls[name] = {
       alias: name,
       zip: `${base}/${MF_TYPES_ZIP}`,
@@ -170,26 +185,126 @@ const deriveRemoteTypeUrls = (
 };
 
 /**
+ * Merge user-supplied `remoteTypeUrls` over the derived ones. The user wins per
+ * field; `alias` defaults to the remote name so an entry that omits it (the
+ * easy-to-forget field promise remotes require) still carries one.
+ */
+const mergeRemoteTypeUrls = (
+  derived: RemoteTypeUrls,
+  user: RemoteTypeUrls
+): RemoteTypeUrls => {
+  const merged: RemoteTypeUrls = { ...derived };
+  Object.entries(user).forEach(([name, entry]) => {
+    merged[name] = { alias: name, ...derived[name], ...entry };
+  });
+  return merged;
+};
+
+/**
+ * A configured `registry` can be queried at build time (jsonp is browser-only,
+ * so `fetch` only) to resolve the live entry a remote would load, closing the
+ * version skew a purely static derivation can carry.
+ */
+const canUseRegistryResolver = (siteConfig: SiteConfig): boolean =>
+  typeof siteConfig.registry === 'string' &&
+  siteConfig.registry !== '*' &&
+  siteConfig.registryType !== 'jsonp' &&
+  typeof fetch === 'function';
+
+/**
+ * Build an async `remoteTypeUrls` resolver (Module Federation's supported
+ * function form) that, per dependency, queries the `registry` with the same
+ * shape the runtime uses and derives the type-archive URL from the resolved
+ * entry. Any failure falls back to the static-derived URL, so type resolution
+ * never fails the build.
+ */
+const createRegistryResolver = (
+  siteConfig: SiteConfig,
+  derived: RemoteTypeUrls
+): (() => Promise<RemoteTypeUrls>) => {
+  const registry = siteConfig.registry as string;
+  const { dependencies, name: main, version: mainVersion } = siteConfig;
+  return async () => {
+    const resolved = await Promise.all(
+      Object.entries(dependencies ?? {}).map(async ([dependency, value]) => {
+        const fallback = derived[dependency];
+        try {
+          const query: Record<string, string> = {
+            name: main ?? '',
+            dependency,
+            main: main ?? '',
+            mainVersion: mainVersion ?? '*',
+            _: Date.now().toString(),
+          };
+          const version = typeof value === 'object' ? value.version : undefined;
+          if (version) query.version = version;
+          const response = await fetch(
+            `${registry}?${new URLSearchParams(query)}`
+          );
+          const data = (await response.json()) as RegistryResponse;
+          const entry = data?.[dependency]?.entry;
+          const base =
+            typeof entry === 'string' ? deriveTypeBase(entry) : undefined;
+          if (!base) return [dependency, fallback] as const;
+          return [
+            dependency,
+            {
+              alias: dependency,
+              zip: `${base}/${MF_TYPES_ZIP}`,
+              api: `${base}/${MF_TYPES_API}`,
+            },
+          ] as const;
+        } catch {
+          return [dependency, fallback] as const;
+        }
+      })
+    );
+    return Object.fromEntries(
+      resolved.filter(
+        (pair): pair is [string, RemoteTypeUrl] => pair[1] !== undefined
+      )
+    );
+  };
+};
+
+/**
+ * Choose the consumer `remoteTypeUrls`: a user resolver/entries always win;
+ * otherwise resolve via the registry when configured, else use the static
+ * derivation.
+ */
+const resolveRemoteTypeUrls = (
+  siteConfig: SiteConfig,
+  derived: RemoteTypeUrls,
+  userRemoteTypeUrls: DtsConsumeTypesOptions['remoteTypeUrls']
+): DtsConsumeTypesOptions['remoteTypeUrls'] => {
+  if (typeof userRemoteTypeUrls === 'function') return userRemoteTypeUrls;
+  if (userRemoteTypeUrls && Object.keys(userRemoteTypeUrls).length > 0) {
+    return mergeRemoteTypeUrls(derived, userRemoteTypeUrls);
+  }
+  if (canUseRegistryResolver(siteConfig)) {
+    return createRegistryResolver(siteConfig, derived);
+  }
+  return derived;
+};
+
+/**
  * Resolve the Module Federation `dts` options for the builder from the opt-in
- * `siteConfig.dts`. Returns `undefined` when `dts` is unset so that nothing
+ * `siteConfig.dts`. Returns `undefined` when `dts` is unset so nothing
  * DTS-shaped is applied and the output stays byte-identical.
  *
  * - Producer: user `generateTypes` options (`tsConfigPath`, `outputDir`,
  *   `additionalFilesToCompile`, ...) pass through untouched. We set no default
  *   `outputDir`: dts-plugin emits `@mf-types.zip` / `@mf-types.d.ts` at the
  *   compiler output root (next to a default `remoteEntry.js`, via the default
- *   `typesFolder` of `@mf-types`), which is exactly the location the consumer
- *   derivation below targets. For a nested `filename`, set `outputDir` to keep
- *   the archive co-located with the remote entry. Note: dts-plugin does not
- *   rewrite tsconfig path-alias imports in the emitted declarations, so a
- *   curated public entry must use only relative or package-resolvable imports.
- * - Consumer: derive `consumeTypes.remoteTypeUrls` from `dependencies`; a
- *   user-supplied entry always wins (a user-supplied function resolver is left
- *   untouched). Default `consumeTypes.typesOnBuild` to `true` when consuming is
- *   on so production builds actually fetch the types.
- *
- * Note: dev-time hot type reload is unsupported in v1; the plugin forces the
- * top-level `dev` option off when handing these options to dts-plugin.
+ *   `typesFolder` of `@mf-types`), which is the location the consumer derivation
+ *   targets. For a nested `filename`, set `outputDir` to keep the archive
+ *   co-located with the remote entry. dts-plugin does not rewrite tsconfig
+ *   path-alias imports in the emitted declarations, so a curated public entry
+ *   must use only relative or package-resolvable imports.
+ * - Consumer: resolve `consumeTypes.remoteTypeUrls` (static derivation, or the
+ *   registry resolver when a `registry` is configured); a user-supplied value
+ *   wins. Default `consumeTypes.typesOnBuild` to `true` when consuming is on so
+ *   production builds actually fetch the types.
  */
 export const getDtsPluginOptions = (
   siteConfig: SiteConfig
@@ -203,27 +318,21 @@ export const getDtsPluginOptions = (
   if (resolved.consumeTypes !== false) {
     const userConsume: DtsConsumeTypesOptions =
       typeof resolved.consumeTypes === 'object' ? resolved.consumeTypes : {};
-    const userRemoteTypeUrls = userConsume.remoteTypeUrls;
-    // A user function resolver takes full control; skip static derivation.
-    const derived =
-      typeof userRemoteTypeUrls === 'function'
-        ? undefined
-        : deriveRemoteTypeUrls(dependencies);
-    const hasDiscovery = !!derived && Object.keys(derived).length > 0;
+    const derived = deriveRemoteTypeUrls(dependencies);
     // Turn consuming on only when the user opted in or a remote was discovered.
-    if (resolved.consumeTypes !== undefined || hasDiscovery) {
+    if (
+      resolved.consumeTypes !== undefined ||
+      Object.keys(derived).length > 0
+    ) {
       resolved.consumeTypes = {
         // Production consumption needs the build-time fetch; MF skips it otherwise.
         typesOnBuild: true,
         ...userConsume,
-        remoteTypeUrls:
-          typeof userRemoteTypeUrls === 'function'
-            ? userRemoteTypeUrls
-            : {
-                ...derived,
-                // A user-supplied entry always wins over the derived one.
-                ...userRemoteTypeUrls,
-              },
+        remoteTypeUrls: resolveRemoteTypeUrls(
+          siteConfig,
+          derived,
+          userConsume.remoteTypeUrls
+        ),
       };
     }
   }

--- a/packages/builder/src/make.ts
+++ b/packages/builder/src/make.ts
@@ -92,7 +92,7 @@ export const makeBannerScript = (
     identifierContainer: typeof import('@ringcentral/mfe-shared').identifierContainer;
     mfeConfig: Pick<
       SiteConfig,
-      Exclude<keyof SiteConfig, 'shared' | 'optimization'>
+      Exclude<keyof SiteConfig, 'shared' | 'optimization' | 'dts'>
     >;
     identifier: string;
     maxRetries: number;

--- a/packages/builder/test/ModuleFederationPlugin.dts.test.ts
+++ b/packages/builder/test/ModuleFederationPlugin.dts.test.ts
@@ -101,3 +101,19 @@ test('SPA build: DtsPlugin is not applied even when dts is set', () => {
   expect(superApplySpy).not.toHaveBeenCalled();
   expect(mockedDtsPlugin).not.toHaveBeenCalled();
 });
+
+test('the banner never serializes the dts config even when dts is set', () => {
+  mockedGetSiteConfig.mockReturnValue({
+    ...baseSiteConfig(),
+    dts: { generateTypes: { outputDir: 'DTS_MARKER_SHOULD_NOT_LEAK' } },
+  });
+  // Construct the real plugin (do NOT replace bannerPlugin) and inspect the
+  // banner string that would be injected into the remote entry.
+  const plugin = new ModuleFederationPlugin();
+  const { banner } = (
+    plugin as unknown as { bannerPlugin: { options: { banner: string } } }
+  ).bannerPlugin.options;
+  expect(banner).toContain('@example/host');
+  expect(banner).not.toContain('DTS_MARKER_SHOULD_NOT_LEAK');
+  expect(banner).not.toContain('"dts"');
+});

--- a/packages/builder/test/ModuleFederationPlugin.dts.test.ts
+++ b/packages/builder/test/ModuleFederationPlugin.dts.test.ts
@@ -69,6 +69,25 @@ test('dts unset: super() options carry no dts/dev/runtimePlugins and no DtsPlugi
   expect(mockedDtsPlugin).not.toHaveBeenCalled();
 });
 
+test('constructor strips dev/runtimePlugins from super() options and warns', () => {
+  const warnSpy = jest
+    .spyOn(console, 'warn')
+    .mockImplementation(() => undefined);
+  mockedGetSiteConfig.mockReturnValue({
+    ...baseSiteConfig(),
+    dev: true,
+    runtimePlugins: [],
+  });
+  const plugin = new ModuleFederationPlugin();
+  const superOptions = (plugin as unknown as { _options: object })._options;
+  expect(superOptions).not.toHaveProperty('dev');
+  expect(superOptions).not.toHaveProperty('runtimePlugins');
+  expect(warnSpy).toHaveBeenCalledWith(
+    expect.stringContaining("'dev'/'runtimePlugins'")
+  );
+  warnSpy.mockRestore();
+});
+
 test('dts set (non-SPA): DtsPlugin applied with dev:false and the resolved dts; super() stays clean', () => {
   mockedGetSiteConfig.mockReturnValue({
     ...baseSiteConfig(),

--- a/packages/builder/test/ModuleFederationPlugin.dts.test.ts
+++ b/packages/builder/test/ModuleFederationPlugin.dts.test.ts
@@ -1,0 +1,103 @@
+import { container } from 'webpack';
+import { DtsPlugin } from '@module-federation/dts-plugin';
+import type { Compiler } from 'webpack';
+import { getSiteConfig } from '../src/getConfig';
+import { getEnv } from '../src/getEnv';
+import { ModuleFederationPlugin } from '../src/ModuleFederationPlugin';
+
+// Keep the real native-config builders; only the file-reading getSiteConfig is
+// stubbed so each test can inject a site config without a fixture file.
+jest.mock('../src/getConfig', () => ({
+  ...jest.requireActual('../src/getConfig'),
+  getSiteConfig: jest.fn(),
+}));
+jest.mock('../src/getEnv', () => ({ getEnv: jest.fn(() => ({})) }));
+jest.mock('@module-federation/dts-plugin', () => ({
+  DtsPlugin: jest.fn().mockImplementation(() => ({ apply: jest.fn() })),
+}));
+
+const mockedGetSiteConfig = getSiteConfig as jest.Mock;
+const mockedGetEnv = getEnv as jest.Mock;
+const mockedDtsPlugin = DtsPlugin as unknown as jest.Mock;
+
+const baseSiteConfig = () => ({
+  name: '@example/host',
+  exposes: { './bootstrap': './src/bootstrap' },
+  dependencies: {
+    '@example/remote': {
+      entry: 'http://localhost:3002/remoteEntry.js',
+      version: '*',
+    },
+  },
+});
+
+let superApplySpy: jest.SpyInstance;
+
+beforeEach(() => {
+  mockedDtsPlugin.mockClear();
+  mockedGetEnv.mockReturnValue({});
+  // Stub the native federation apply so no real compiler is required.
+  superApplySpy = jest
+    .spyOn(container.ModuleFederationPlugin.prototype, 'apply')
+    .mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  superApplySpy.mockRestore();
+});
+
+const buildPlugin = () => {
+  const plugin = new ModuleFederationPlugin();
+  // Replace the webpack sub-plugins so apply() needs no real compiler.
+  (plugin as unknown as { bannerPlugin: { apply: jest.Mock } }).bannerPlugin = {
+    apply: jest.fn(),
+  };
+  (plugin as unknown as { definePlugin: { apply: jest.Mock } }).definePlugin = {
+    apply: jest.fn(),
+  };
+  return plugin;
+};
+
+test('dts unset: super() options carry no dts/dev/runtimePlugins and no DtsPlugin is applied', () => {
+  mockedGetSiteConfig.mockReturnValue(baseSiteConfig());
+  const plugin = buildPlugin();
+  const superOptions = (plugin as unknown as { _options: object })._options;
+  expect(superOptions).not.toHaveProperty('dts');
+  expect(superOptions).not.toHaveProperty('dev');
+  expect(superOptions).not.toHaveProperty('runtimePlugins');
+  plugin.apply({} as Compiler);
+  expect(mockedDtsPlugin).not.toHaveBeenCalled();
+});
+
+test('dts set (non-SPA): DtsPlugin applied with dev:false and the resolved dts; super() stays clean', () => {
+  mockedGetSiteConfig.mockReturnValue({
+    ...baseSiteConfig(),
+    dts: { generateTypes: true, consumeTypes: true },
+  });
+  const plugin = buildPlugin();
+  expect(
+    (plugin as unknown as { _options: object })._options
+  ).not.toHaveProperty('dts');
+  plugin.apply({} as Compiler);
+  expect(mockedDtsPlugin).toHaveBeenCalledTimes(1);
+  const arg = mockedDtsPlugin.mock.calls[0][0];
+  expect(arg.name).toBe('@example/host');
+  expect(arg.dev).toBe(false);
+  expect(arg.dts.consumeTypes.remoteTypeUrls['@example/remote']).toEqual({
+    alias: '@example/remote',
+    zip: 'http://localhost:3002/@mf-types.zip',
+    api: 'http://localhost:3002/@mf-types.d.ts',
+  });
+});
+
+test('SPA build: DtsPlugin is not applied even when dts is set', () => {
+  mockedGetSiteConfig.mockReturnValue({
+    ...baseSiteConfig(),
+    dts: { generateTypes: true },
+  });
+  mockedGetEnv.mockReturnValue({ spa: true });
+  const plugin = buildPlugin();
+  plugin.apply({} as Compiler);
+  expect(superApplySpy).not.toHaveBeenCalled();
+  expect(mockedDtsPlugin).not.toHaveBeenCalled();
+});

--- a/packages/builder/test/ModuleFederationPlugin.dtsMissing.test.ts
+++ b/packages/builder/test/ModuleFederationPlugin.dtsMissing.test.ts
@@ -33,7 +33,7 @@ afterEach(() => {
   superApplySpy.mockRestore();
 });
 
-test('apply throws a clear opt-in error when @module-federation/dts-plugin is not installed', () => {
+test('apply throws a clear error when the optional @module-federation/dts-plugin cannot be loaded', () => {
   mockedGetSiteConfig.mockReturnValue({
     name: '@example/host',
     exposes: { './bootstrap': './src/bootstrap' },
@@ -60,5 +60,6 @@ test('apply throws a clear opt-in error when @module-federation/dts-plugin is no
   }
   expect(thrown).toBeDefined();
   expect(thrown?.message).toMatch(/@module-federation\/dts-plugin/);
+  expect(thrown?.message).toMatch(/optional dependency/);
   expect(thrown?.message).toMatch(/Node >=20\.18\.1/);
 });

--- a/packages/builder/test/ModuleFederationPlugin.dtsMissing.test.ts
+++ b/packages/builder/test/ModuleFederationPlugin.dtsMissing.test.ts
@@ -1,0 +1,64 @@
+import { container } from 'webpack';
+import type { Compiler } from 'webpack';
+import { getSiteConfig } from '../src/getConfig';
+import { ModuleFederationPlugin } from '../src/ModuleFederationPlugin';
+
+// Keep the real native-config builders; only the file-reading getSiteConfig is
+// stubbed so the test can inject a dts-enabled config without a fixture file.
+jest.mock('../src/getConfig', () => ({
+  ...jest.requireActual('../src/getConfig'),
+  getSiteConfig: jest.fn(),
+}));
+// Simulate the optional peer being absent: requiring it fails with the same
+// error shape Node throws when a module cannot be resolved.
+jest.mock('@module-federation/dts-plugin', () => {
+  const error: NodeJS.ErrnoException = new Error(
+    "Cannot find module '@module-federation/dts-plugin'"
+  );
+  error.code = 'MODULE_NOT_FOUND';
+  throw error;
+});
+
+const mockedGetSiteConfig = getSiteConfig as jest.Mock;
+
+let superApplySpy: jest.SpyInstance;
+
+beforeEach(() => {
+  superApplySpy = jest
+    .spyOn(container.ModuleFederationPlugin.prototype, 'apply')
+    .mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  superApplySpy.mockRestore();
+});
+
+test('apply throws a clear opt-in error when @module-federation/dts-plugin is not installed', () => {
+  mockedGetSiteConfig.mockReturnValue({
+    name: '@example/host',
+    exposes: { './bootstrap': './src/bootstrap' },
+    dependencies: {
+      '@example/remote': {
+        entry: 'http://localhost:3002/remoteEntry.js',
+        version: '*',
+      },
+    },
+    dts: { generateTypes: true },
+  });
+  const plugin = new ModuleFederationPlugin();
+  (plugin as unknown as { bannerPlugin: { apply: jest.Mock } }).bannerPlugin = {
+    apply: jest.fn(),
+  };
+  (plugin as unknown as { definePlugin: { apply: jest.Mock } }).definePlugin = {
+    apply: jest.fn(),
+  };
+  let thrown: Error | undefined;
+  try {
+    plugin.apply({} as Compiler);
+  } catch (e) {
+    thrown = e as Error;
+  }
+  expect(thrown).toBeDefined();
+  expect(thrown?.message).toMatch(/@module-federation\/dts-plugin/);
+  expect(thrown?.message).toMatch(/Node >=20\.18\.1/);
+});

--- a/packages/builder/test/getDtsPluginOptions.test.ts
+++ b/packages/builder/test/getDtsPluginOptions.test.ts
@@ -190,9 +190,15 @@ test('getModuleFederationConfig strips dts from the native options', () => {
 
 describe('registry-aware remoteTypeUrls resolver', () => {
   const originalFetch = global.fetch;
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
 
   afterEach(() => {
     global.fetch = originalFetch;
+    warnSpy.mockRestore();
   });
 
   test('resolves remoteTypeUrls from the registry-resolved entry', async () => {
@@ -232,6 +238,8 @@ describe('registry-aware remoteTypeUrls resolver', () => {
     expect(urls['@x/remote'].zip).toBe(
       'https://cdn.example.com/v2/remote/@mf-types.zip'
     );
+    // a successful lookup must not warn
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   test('keeps the static URL when the registry entry does not satisfy the version', async () => {
@@ -262,6 +270,9 @@ describe('registry-aware remoteTypeUrls resolver', () => {
     expect(urls['@x/remote'].zip).toBe(
       'https://cdn.example.com/v1/remote/@mf-types.zip'
     );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('did not satisfy the required version')
+    );
   });
 
   test('falls back to the static URL when the registry fetch fails', async () => {
@@ -284,6 +295,9 @@ describe('registry-aware remoteTypeUrls resolver', () => {
     )();
     expect(urls['@x/remote'].zip).toBe(
       'https://cdn.example.com/v1/remote/@mf-types.zip'
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("registry lookup failed for '@x/remote'")
     );
   });
 

--- a/packages/builder/test/getDtsPluginOptions.test.ts
+++ b/packages/builder/test/getDtsPluginOptions.test.ts
@@ -176,7 +176,7 @@ test('passes producer generateTypes options (incl. outputDir) through untouched'
   expect(resolved?.generateTypes).toEqual(generateTypes);
 });
 
-test('getModuleFederationConfig strips dts/dev/runtimePlugins from native options', () => {
+test('getModuleFederationConfig strips dts from the native options', () => {
   const cfg = getModuleFederationConfig({
     name: '@x/host',
     exposes: { './bootstrap': './src/bootstrap' },
@@ -186,8 +186,6 @@ test('getModuleFederationConfig strips dts/dev/runtimePlugins from native option
     dts: {},
   } as unknown as SiteConfig);
   expect(cfg).not.toHaveProperty('dts');
-  expect(cfg).not.toHaveProperty('dev');
-  expect(cfg).not.toHaveProperty('runtimePlugins');
 });
 
 describe('registry-aware remoteTypeUrls resolver', () => {
@@ -210,10 +208,10 @@ describe('registry-aware remoteTypeUrls resolver', () => {
       name: '@x/host',
       version: '1.2.3',
       registry: 'https://registry.example.com/lookup',
+      registryAutoFetch: true,
       dependencies: {
         '@x/remote': {
           entry: 'https://cdn.example.com/v1/remote/remoteEntry.js',
-          version: '^2',
         },
       },
       dts: {},
@@ -228,10 +226,41 @@ describe('registry-aware remoteTypeUrls resolver', () => {
     expect(calledUrl).toContain('dependency=%40x%2Fremote');
     expect(calledUrl).toContain('main=%40x%2Fhost');
     expect(calledUrl).toContain('mainVersion=1.2.3');
-    expect(calledUrl).toContain('version=%5E2');
+    // the query carries the consumer's version, not the remote's
+    expect(calledUrl).toContain('version=1.2.3');
     // derived from the registry entry (v2), not the static entry (v1)
     expect(urls['@x/remote'].zip).toBe(
       'https://cdn.example.com/v2/remote/@mf-types.zip'
+    );
+  });
+
+  test('keeps the static URL when the registry entry does not satisfy the version', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      json: async () => ({
+        '@x/remote': {
+          entry: 'https://cdn.example.com/v2/remote/remoteEntry.js',
+          version: '2.0.0',
+        },
+      }),
+    }) as unknown as typeof fetch;
+    const consumeTypes = consumeTypesOf({
+      name: '@x/host',
+      registry: 'https://registry.example.com/lookup',
+      registryAutoFetch: true,
+      dependencies: {
+        '@x/remote': {
+          entry: 'https://cdn.example.com/v1/remote/remoteEntry.js',
+          dependencyVersion: '^1.0.0',
+        },
+      },
+      dts: {},
+    } as unknown as SiteConfig);
+    const urls = await (
+      consumeTypes.remoteTypeUrls as () => Promise<RemoteTypeUrls>
+    )();
+    // 2.0.0 does not satisfy ^1.0.0 -> keep the static (v1) URL
+    expect(urls['@x/remote'].zip).toBe(
+      'https://cdn.example.com/v1/remote/@mf-types.zip'
     );
   });
 
@@ -242,6 +271,7 @@ describe('registry-aware remoteTypeUrls resolver', () => {
     const consumeTypes = consumeTypesOf({
       name: '@x/host',
       registry: 'https://registry.example.com/lookup',
+      registryAutoFetch: true,
       dependencies: {
         '@x/remote': {
           entry: 'https://cdn.example.com/v1/remote/remoteEntry.js',
@@ -257,11 +287,29 @@ describe('registry-aware remoteTypeUrls resolver', () => {
     );
   });
 
+  test('does not use the resolver when registryAutoFetch is not enabled', () => {
+    global.fetch = jest.fn() as unknown as typeof fetch;
+    const consumeTypes = consumeTypesOf({
+      registry: 'https://registry.example.com/lookup',
+      dependencies: {
+        '@x/remote': {
+          entry: 'https://cdn.example.com/v1/remote/remoteEntry.js',
+        },
+      },
+      dts: {},
+    } as unknown as SiteConfig);
+    expect(typeof consumeTypes.remoteTypeUrls).toBe('object');
+    expect(urlsOf(consumeTypes)['@x/remote'].zip).toBe(
+      'https://cdn.example.com/v1/remote/@mf-types.zip'
+    );
+  });
+
   test('does not use the resolver for a jsonp registry (static object instead)', () => {
     global.fetch = jest.fn() as unknown as typeof fetch;
     const consumeTypes = consumeTypesOf({
       registry: 'https://registry.example.com/lookup',
       registryType: 'jsonp',
+      registryAutoFetch: true,
       dependencies: {
         '@x/remote': {
           entry: 'https://cdn.example.com/v1/remote/remoteEntry.js',
@@ -292,6 +340,7 @@ describe('registry-aware remoteTypeUrls resolver', () => {
     global.fetch = jest.fn() as unknown as typeof fetch;
     const consumeTypes = consumeTypesOf({
       registry: 'https://registry.example.com/lookup',
+      registryAutoFetch: true,
       dependencies: {
         '@x/remote': {
           entry: 'https://cdn.example.com/v1/remote/remoteEntry.js',

--- a/packages/builder/test/getDtsPluginOptions.test.ts
+++ b/packages/builder/test/getDtsPluginOptions.test.ts
@@ -4,6 +4,7 @@ import {
 } from '../src/getConfig';
 import type {
   DtsConsumeTypesOptions,
+  RemoteTypeUrls,
   SiteConfig,
 } from '@ringcentral/mfe-shared';
 
@@ -11,6 +12,12 @@ const consumeTypesOf = (config: SiteConfig): DtsConsumeTypesOptions => {
   const resolved = getDtsPluginOptions(config);
   return resolved?.consumeTypes as DtsConsumeTypesOptions;
 };
+
+const urlsOf = (consumeTypes: DtsConsumeTypesOptions) =>
+  consumeTypes.remoteTypeUrls as Record<
+    string,
+    { alias?: string; zip: string; api: string }
+  >;
 
 test('returns undefined when dts is unset', () => {
   expect(
@@ -48,16 +55,41 @@ test('strips a nested path segment when deriving the base', () => {
     },
     dts: {},
   } as unknown as SiteConfig);
-  const urls = consumeTypes.remoteTypeUrls as Record<
-    string,
-    { zip: string; api: string }
-  >;
+  const urls = urlsOf(consumeTypes);
   expect(urls['@x/remote'].zip).toBe(
     'https://cdn.example.com/apps/remote/@mf-types.zip'
   );
   expect(urls['@x/remote'].api).toBe(
     'https://cdn.example.com/apps/remote/@mf-types.d.ts'
   );
+});
+
+test('derives a correct base for bare-origin and query-string entries', () => {
+  const consumeTypes = consumeTypesOf({
+    dependencies: {
+      bare: { entry: 'https://host.com' },
+      query: { entry: 'https://host.com/app/remoteEntry.js?path=/a/b' },
+      trailing: { entry: 'https://host.com/app/' },
+    },
+    dts: {},
+  } as unknown as SiteConfig);
+  const urls = urlsOf(consumeTypes);
+  expect(urls.bare.zip).toBe('https://host.com/@mf-types.zip');
+  expect(urls.query.zip).toBe('https://host.com/app/@mf-types.zip');
+  expect(urls.trailing.zip).toBe('https://host.com/app/@mf-types.zip');
+});
+
+test('skips an unparsable entry but keeps the valid ones', () => {
+  const consumeTypes = consumeTypesOf({
+    dependencies: {
+      good: { entry: 'http://host/remoteEntry.js' },
+      bad: { entry: 'not a url' },
+    },
+    dts: {},
+  } as unknown as SiteConfig);
+  const urls = urlsOf(consumeTypes);
+  expect(urls.good).toBeDefined();
+  expect(urls.bad).toBeUndefined();
 });
 
 test('a user-supplied remoteTypeUrls entry wins over the derived one', () => {
@@ -72,9 +104,53 @@ test('a user-supplied remoteTypeUrls entry wins over the derived one', () => {
     },
     dts: { consumeTypes: { remoteTypeUrls: { '@x/remote': custom } } },
   } as unknown as SiteConfig);
-  expect(
-    (consumeTypes.remoteTypeUrls as Record<string, unknown>)['@x/remote']
-  ).toEqual(custom);
+  expect(urlsOf(consumeTypes)['@x/remote']).toEqual(custom);
+});
+
+test('a user entry without alias keeps the derived alias (the remote name)', () => {
+  const consumeTypes = consumeTypesOf({
+    dependencies: {
+      '@x/remote': { entry: 'http://localhost:3002/remoteEntry.js' },
+    },
+    dts: {
+      consumeTypes: {
+        remoteTypeUrls: {
+          '@x/remote': {
+            zip: 'https://custom.example.com/types.zip',
+            api: 'https://custom.example.com/types.d.ts',
+          },
+        },
+      },
+    },
+  } as unknown as SiteConfig);
+  const entry = urlsOf(consumeTypes)['@x/remote'];
+  expect(entry.alias).toBe('@x/remote');
+  expect(entry.zip).toBe('https://custom.example.com/types.zip');
+  expect(entry.api).toBe('https://custom.example.com/types.d.ts');
+});
+
+test('a user-supplied function resolver passes through untouched', () => {
+  const resolver = async (): Promise<RemoteTypeUrls> => ({});
+  const consumeTypes = consumeTypesOf({
+    dependencies: {
+      '@x/remote': { entry: 'http://localhost:3002/remoteEntry.js' },
+    },
+    dts: { consumeTypes: { remoteTypeUrls: resolver } },
+  } as unknown as SiteConfig);
+  expect(consumeTypes.remoteTypeUrls).toBe(resolver);
+});
+
+test('consumeTypes: true is normalized to an object with derived remoteTypeUrls', () => {
+  const consumeTypes = consumeTypesOf({
+    dependencies: {
+      '@x/remote': { entry: 'http://localhost:3002/remoteEntry.js' },
+    },
+    dts: { consumeTypes: true },
+  } as unknown as SiteConfig);
+  expect(consumeTypes.typesOnBuild).toBe(true);
+  expect(urlsOf(consumeTypes)['@x/remote'].zip).toBe(
+    'http://localhost:3002/@mf-types.zip'
+  );
 });
 
 test('does not turn consuming on when the user opted out', () => {
@@ -100,15 +176,142 @@ test('passes producer generateTypes options (incl. outputDir) through untouched'
   expect(resolved?.generateTypes).toEqual(generateTypes);
 });
 
-test('getModuleFederationConfig never emits dts/dev/runtimePlugins', () => {
+test('getModuleFederationConfig strips dts/dev/runtimePlugins from native options', () => {
   const cfg = getModuleFederationConfig({
     name: '@x/host',
     exposes: { './bootstrap': './src/bootstrap' },
     dependencies: {
       '@x/remote': { entry: 'http://localhost:3002/remoteEntry.js' },
     },
+    dts: {},
   } as unknown as SiteConfig);
   expect(cfg).not.toHaveProperty('dts');
   expect(cfg).not.toHaveProperty('dev');
   expect(cfg).not.toHaveProperty('runtimePlugins');
+});
+
+describe('registry-aware remoteTypeUrls resolver', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  test('resolves remoteTypeUrls from the registry-resolved entry', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      json: async () => ({
+        '@x/remote': {
+          entry: 'https://cdn.example.com/v2/remote/remoteEntry.js',
+        },
+      }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const consumeTypes = consumeTypesOf({
+      name: '@x/host',
+      version: '1.2.3',
+      registry: 'https://registry.example.com/lookup',
+      dependencies: {
+        '@x/remote': {
+          entry: 'https://cdn.example.com/v1/remote/remoteEntry.js',
+          version: '^2',
+        },
+      },
+      dts: {},
+    } as unknown as SiteConfig);
+    expect(typeof consumeTypes.remoteTypeUrls).toBe('function');
+
+    const urls = await (
+      consumeTypes.remoteTypeUrls as () => Promise<RemoteTypeUrls>
+    )();
+    const calledUrl = fetchMock.mock.calls[0][0] as string;
+    expect(calledUrl).toContain('https://registry.example.com/lookup?');
+    expect(calledUrl).toContain('dependency=%40x%2Fremote');
+    expect(calledUrl).toContain('main=%40x%2Fhost');
+    expect(calledUrl).toContain('mainVersion=1.2.3');
+    expect(calledUrl).toContain('version=%5E2');
+    // derived from the registry entry (v2), not the static entry (v1)
+    expect(urls['@x/remote'].zip).toBe(
+      'https://cdn.example.com/v2/remote/@mf-types.zip'
+    );
+  });
+
+  test('falls back to the static URL when the registry fetch fails', async () => {
+    global.fetch = jest
+      .fn()
+      .mockRejectedValue(new Error('network')) as unknown as typeof fetch;
+    const consumeTypes = consumeTypesOf({
+      name: '@x/host',
+      registry: 'https://registry.example.com/lookup',
+      dependencies: {
+        '@x/remote': {
+          entry: 'https://cdn.example.com/v1/remote/remoteEntry.js',
+        },
+      },
+      dts: {},
+    } as unknown as SiteConfig);
+    const urls = await (
+      consumeTypes.remoteTypeUrls as () => Promise<RemoteTypeUrls>
+    )();
+    expect(urls['@x/remote'].zip).toBe(
+      'https://cdn.example.com/v1/remote/@mf-types.zip'
+    );
+  });
+
+  test('does not use the resolver for a jsonp registry (static object instead)', () => {
+    global.fetch = jest.fn() as unknown as typeof fetch;
+    const consumeTypes = consumeTypesOf({
+      registry: 'https://registry.example.com/lookup',
+      registryType: 'jsonp',
+      dependencies: {
+        '@x/remote': {
+          entry: 'https://cdn.example.com/v1/remote/remoteEntry.js',
+        },
+      },
+      dts: {},
+    } as unknown as SiteConfig);
+    expect(typeof consumeTypes.remoteTypeUrls).toBe('object');
+    expect(urlsOf(consumeTypes)['@x/remote'].zip).toBe(
+      'https://cdn.example.com/v1/remote/@mf-types.zip'
+    );
+  });
+
+  test('does not use the resolver when no registry is configured', () => {
+    global.fetch = jest.fn() as unknown as typeof fetch;
+    const consumeTypes = consumeTypesOf({
+      dependencies: {
+        '@x/remote': {
+          entry: 'https://cdn.example.com/v1/remote/remoteEntry.js',
+        },
+      },
+      dts: {},
+    } as unknown as SiteConfig);
+    expect(typeof consumeTypes.remoteTypeUrls).toBe('object');
+  });
+
+  test('a user-supplied remoteTypeUrls wins over the registry resolver', () => {
+    global.fetch = jest.fn() as unknown as typeof fetch;
+    const consumeTypes = consumeTypesOf({
+      registry: 'https://registry.example.com/lookup',
+      dependencies: {
+        '@x/remote': {
+          entry: 'https://cdn.example.com/v1/remote/remoteEntry.js',
+        },
+      },
+      dts: {
+        consumeTypes: {
+          remoteTypeUrls: {
+            '@x/remote': {
+              alias: '@x/remote',
+              zip: 'https://custom.example.com/t.zip',
+              api: 'https://custom.example.com/t.d.ts',
+            },
+          },
+        },
+      },
+    } as unknown as SiteConfig);
+    expect(typeof consumeTypes.remoteTypeUrls).toBe('object');
+    expect(urlsOf(consumeTypes)['@x/remote'].zip).toBe(
+      'https://custom.example.com/t.zip'
+    );
+  });
 });

--- a/packages/builder/test/getDtsPluginOptions.test.ts
+++ b/packages/builder/test/getDtsPluginOptions.test.ts
@@ -1,0 +1,114 @@
+import {
+  getDtsPluginOptions,
+  getModuleFederationConfig,
+} from '../src/getConfig';
+import type {
+  DtsConsumeTypesOptions,
+  SiteConfig,
+} from '@ringcentral/mfe-shared';
+
+const consumeTypesOf = (config: SiteConfig): DtsConsumeTypesOptions => {
+  const resolved = getDtsPluginOptions(config);
+  return resolved?.consumeTypes as DtsConsumeTypesOptions;
+};
+
+test('returns undefined when dts is unset', () => {
+  expect(
+    getDtsPluginOptions({ name: '@x/host', dependencies: {} } as SiteConfig)
+  ).toBeUndefined();
+});
+
+test('derives remoteTypeUrls from a string-entry dependency', () => {
+  const consumeTypes = consumeTypesOf({
+    name: '@x/host',
+    dependencies: {
+      '@x/remote': {
+        entry: 'http://localhost:3002/remoteEntry.js',
+        version: '*',
+      },
+    },
+    dts: {},
+  } as SiteConfig);
+  expect(consumeTypes.typesOnBuild).toBe(true);
+  expect(consumeTypes.remoteTypeUrls).toEqual({
+    '@x/remote': {
+      alias: '@x/remote',
+      zip: 'http://localhost:3002/@mf-types.zip',
+      api: 'http://localhost:3002/@mf-types.d.ts',
+    },
+  });
+});
+
+test('strips a nested path segment when deriving the base', () => {
+  const consumeTypes = consumeTypesOf({
+    dependencies: {
+      '@x/remote': {
+        entry: 'https://cdn.example.com/apps/remote/remoteEntry.js',
+      },
+    },
+    dts: {},
+  } as unknown as SiteConfig);
+  const urls = consumeTypes.remoteTypeUrls as Record<
+    string,
+    { zip: string; api: string }
+  >;
+  expect(urls['@x/remote'].zip).toBe(
+    'https://cdn.example.com/apps/remote/@mf-types.zip'
+  );
+  expect(urls['@x/remote'].api).toBe(
+    'https://cdn.example.com/apps/remote/@mf-types.d.ts'
+  );
+});
+
+test('a user-supplied remoteTypeUrls entry wins over the derived one', () => {
+  const custom = {
+    alias: '@x/remote',
+    zip: 'https://custom.example.com/types.zip',
+    api: 'https://custom.example.com/types.d.ts',
+  };
+  const consumeTypes = consumeTypesOf({
+    dependencies: {
+      '@x/remote': { entry: 'http://localhost:3002/remoteEntry.js' },
+    },
+    dts: { consumeTypes: { remoteTypeUrls: { '@x/remote': custom } } },
+  } as unknown as SiteConfig);
+  expect(
+    (consumeTypes.remoteTypeUrls as Record<string, unknown>)['@x/remote']
+  ).toEqual(custom);
+});
+
+test('does not turn consuming on when the user opted out', () => {
+  const resolved = getDtsPluginOptions({
+    dependencies: {
+      '@x/remote': { entry: 'http://localhost:3002/remoteEntry.js' },
+    },
+    dts: { generateTypes: true, consumeTypes: false },
+  } as unknown as SiteConfig);
+  expect(resolved?.consumeTypes).toBe(false);
+});
+
+test('passes producer generateTypes options (incl. outputDir) through untouched', () => {
+  const generateTypes = {
+    tsConfigPath: './tsconfig.types.json',
+    outputDir: 'dist/remote',
+    additionalFilesToCompile: ['./src/public.ts'],
+  };
+  const resolved = getDtsPluginOptions({
+    dependencies: {},
+    dts: { generateTypes },
+  } as unknown as SiteConfig);
+  expect(resolved?.generateTypes).toEqual(generateTypes);
+});
+
+test('getModuleFederationConfig never emits dts/dev/runtimePlugins', () => {
+  const cfg = getModuleFederationConfig({
+    name: '@x/host',
+    exposes: { './bootstrap': './src/bootstrap' },
+    dependencies: {
+      '@x/remote': { entry: 'http://localhost:3002/remoteEntry.js' },
+    },
+  } as unknown as SiteConfig);
+  expect(cfg).not.toHaveProperty('dts');
+  expect(cfg).not.toHaveProperty('dev');
+  expect(cfg).not.toHaveProperty('runtimePlugins');
+});

--- a/packages/shared/src/interface.ts
+++ b/packages/shared/src/interface.ts
@@ -174,8 +174,9 @@ export interface DtsConsumeTypesOptions {
 
 /**
  * Opt-in Module Federation type options, mirroring
- * `@module-federation/dts-plugin`'s `PluginDtsOptions`. Declared here so the
- * builder does not take a hard dependency on the optional peer package.
+ * `@module-federation/dts-plugin`'s `PluginDtsOptions` (as of v2.8.0). Declared
+ * here so the builder does not take a hard dependency on the optional peer
+ * package.
  */
 export interface PluginDtsOptions {
   generateTypes?: boolean | DtsGenerateTypesOptions;

--- a/packages/shared/src/interface.ts
+++ b/packages/shared/src/interface.ts
@@ -95,6 +95,98 @@ export interface SiteOverridableConfig {
   projectRoot?: string;
 }
 
+/**
+ * A single remote's published type-archive locations, as consumed by
+ * `@module-federation/dts-plugin`.
+ */
+export interface RemoteTypeUrl {
+  /**
+   * The remote's federation alias. The builder always sets this to the remote
+   * name; promise-style remotes require it to consume types.
+   */
+  alias?: string;
+  /**
+   * URL of the flat `@mf-types.d.ts` API declaration.
+   */
+  api: string;
+  /**
+   * URL of the `@mf-types.zip` type archive.
+   */
+  zip: string;
+}
+
+export type RemoteTypeUrls = Record<string, RemoteTypeUrl>;
+
+/**
+ * Producer-side type generation options, mirroring
+ * `@module-federation/dts-plugin`'s `DtsRemoteOptions`.
+ */
+export interface DtsGenerateTypesOptions {
+  tsConfigPath?: string;
+  typesFolder?: string;
+  compiledTypesFolder?: string;
+  deleteTypesFolder?: boolean;
+  additionalFilesToCompile?: string[];
+  /**
+   * Directory the type archive is emitted to (relative to the compiler
+   * context). Defaults to the compiler output root, i.e. next to
+   * `remoteEntry.js` — set it to match a nested `filename` directory so the
+   * archive stays co-located with the remote entry.
+   */
+  outputDir?: string;
+  compileInChildProcess?: boolean;
+  compilerInstance?: 'tsc' | 'vue-tsc' | 'tspc' | string;
+  generateAPITypes?: boolean;
+  extractThirdParty?: boolean | { exclude?: Array<string | RegExp> };
+  extractRemoteTypes?: boolean;
+  abortOnError?: boolean;
+  deleteTsConfig?: boolean;
+}
+
+/**
+ * Consumer-side type options, mirroring
+ * `@module-federation/dts-plugin`'s `DtsHostOptions`.
+ */
+export interface DtsConsumeTypesOptions {
+  typesFolder?: string;
+  abortOnError?: boolean;
+  remoteTypesFolder?: string;
+  deleteTypesFolder?: boolean;
+  maxRetries?: number;
+  consumeAPITypes?: boolean;
+  runtimePkgs?: string[];
+  /**
+   * Static per-remote type-archive locations. The builder derives these from
+   * the declared `dependencies`; user-supplied entries win.
+   */
+  remoteTypeUrls?: RemoteTypeUrls | (() => Promise<RemoteTypeUrls>);
+  timeout?: number;
+  /**
+   * IP family used for network requests.
+   */
+  family?: 4 | 6;
+  /**
+   * Fetch and unpack remote types during the build. Required for the builder's
+   * production consumption (MF skips the fetch otherwise).
+   */
+  typesOnBuild?: boolean;
+}
+
+/**
+ * Opt-in Module Federation type options, mirroring
+ * `@module-federation/dts-plugin`'s `PluginDtsOptions`. Declared here so the
+ * builder does not take a hard dependency on the optional peer package.
+ */
+export interface PluginDtsOptions {
+  generateTypes?: boolean | DtsGenerateTypesOptions;
+  consumeTypes?: boolean | DtsConsumeTypesOptions;
+  tsConfigPath?: string;
+  extraOptions?: Record<string, unknown>;
+  implementation?: string;
+  cwd?: string;
+  displayErrorInTerminal?: boolean;
+}
+
 export interface SiteConfig
   extends Pick<
       ModuleFederationPluginOptions,
@@ -121,6 +213,15 @@ export interface SiteConfig
      */
     injectMeta?: Rule[];
   };
+
+  /**
+   * Opt-in federated types. When set, the builder wires
+   * `@module-federation/dts-plugin` (an optional peer dependency) to emit the
+   * standard `@mf-types.zip` / `@mf-types.d.ts` for producers and to consume
+   * remote types for consumers. Unset means byte-identical output and no extra
+   * dependency. See `PluginDtsOptions`.
+   */
+  dts?: PluginDtsOptions;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/yarn.lock
+++ b/yarn.lock
@@ -838,10 +838,36 @@
     write-pkg "4.0.0"
     yargs "16.2.0"
 
+"@module-federation/dts-plugin@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@module-federation/dts-plugin/-/dts-plugin-2.8.0.tgz#e806d9db72bdaf944ea24f163d3dd9b0cc40f2d0"
+  integrity sha512-defjq4jOWMEfeejezPWLP5sc8kw0O6FqTT7/E5rbZPEVyjB1A0U3ynhW6GDE5/6hk9/TzdbWS+fBNi4MqUOY6Q==
+  dependencies:
+    "@module-federation/error-codes" "2.8.0"
+    "@module-federation/managers" "2.8.0"
+    "@module-federation/sdk" "2.8.0"
+    "@module-federation/third-party-dts-extractor" "2.8.0"
+    adm-zip "0.5.10"
+    isomorphic-ws "5.0.0"
+    undici "7.28.0"
+    ws "8.21.0"
+
 "@module-federation/error-codes@0.22.0":
   version "0.22.0"
   resolved "https://registry.yarnpkg.com/@module-federation/error-codes/-/error-codes-0.22.0.tgz#31ccc990dc240d73912ba7bd001f7e35ac751992"
   integrity sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug==
+
+"@module-federation/error-codes@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@module-federation/error-codes/-/error-codes-2.8.0.tgz#c5c24c64a0349cc160ebedbc1595ec3de3149c3f"
+  integrity sha512-Gaog9904EmxYOQV0hli3XQ7jXeFaADfh5bnBtTCtbZ37Qd/Sz9kQfd+gYQRyIj7RGmkv9DPiN/SsmrTMrTymKw==
+
+"@module-federation/managers@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@module-federation/managers/-/managers-2.8.0.tgz#deb02fbc7c20d4179b00c3879a89bb7d29e961cc"
+  integrity sha512-SnVBCwmi962WGg6hLFElxZUCnrRJdR6glE2ZKPBY/iK07AHUN2ZxuaBCBsVzyws+xLZGHZxBHmVstijTh8dSUA==
+  dependencies:
+    "@module-federation/sdk" "2.8.0"
 
 "@module-federation/runtime-core@0.22.0":
   version "0.22.0"
@@ -872,6 +898,16 @@
   version "0.22.0"
   resolved "https://registry.yarnpkg.com/@module-federation/sdk/-/sdk-0.22.0.tgz#6ad4c1de85a900c3c80ff26cb87cce253e3a2770"
   integrity sha512-x4aFNBKn2KVQRuNVC5A7SnrSCSqyfIWmm1DvubjbO9iKFe7ith5niw8dqSFBekYBg2Fwy+eMg4sEFNVvCAdo6g==
+
+"@module-federation/sdk@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@module-federation/sdk/-/sdk-2.8.0.tgz#c4b5c896a6b9df23cbe5fa9c8b622529ac82267b"
+  integrity sha512-yBP+9+0Z8nlvKEXAZS3AsQVy7bFbZf8eMivGk4q4ZdwG3TsLMlsPjb1dQb2i7gcAG6ux9y2LWLkj/0LVk74cnQ==
+
+"@module-federation/third-party-dts-extractor@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.8.0.tgz#0af29671261ab0b6061cddf61d5bdd9487cb012b"
+  integrity sha512-nAMlr74OKIylkfRwlunOhytQbmsgb3gCqdXWnPQhG+ZtqWXGELLfMT4a1Q1ht3cS+sRpWj2SZRqK2M7GadI6tA==
 
 "@module-federation/webpack-bundler-runtime@0.22.0":
   version "0.22.0"
@@ -2211,6 +2247,11 @@ add-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz"
   integrity sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==
+
+adm-zip@0.5.10:
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.5.10.tgz#4a51d5ab544b1f5ce51e1b9043139b639afff45b"
+  integrity sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==
 
 agent-base@6, agent-base@^6.0.2:
   version "6.0.2"
@@ -6049,6 +6090,11 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz"
   integrity sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==
+
+isomorphic-ws@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz#e5529148912ecb9b451b46ed44d53dae1ce04bbf"
+  integrity sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==
 
 isstream@0.1.x:
   version "0.1.2"
@@ -10248,6 +10294,11 @@ unbox-primitive@^1.0.2:
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
 
+undici@7.28.0:
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
+  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
+
 union-value@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz"
@@ -10820,6 +10871,11 @@ write-pkg@4.0.0:
     sort-keys "^2.0.0"
     type-fest "^0.4.1"
     write-json-file "^3.2.0"
+
+ws@8.21.0:
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 ws@^8.11.0:
   version "8.16.0"


### PR DESCRIPTION
## Summary

Adds an **opt-in `dts` capability** to `ModuleFederationPlugin` so remotes built with this (native-container) builder can emit and consume the standard Module Federation `@mf-types` type artifacts — without adopting `@module-federation/enhanced`, without the enhanced runtime, and without changing the container runtime or the `__RC_MFE__` registry.

It's **off by default**: with `dts` unset the build output is byte-for-byte identical to today.

This is a proposal — I'd love maintainer feedback on the approach before polishing (see Open questions). Happy to iterate.

## Motivation

Remotes built with this builder have no build-time type contract today; consumers hand-copy declarations or go untyped. Module Federation already ships a mechanism for this (`@module-federation/dts-plugin`) — this wires it into the builder generally, so any remote gets the standard `@mf-types` consumer DX.

## How it works

- **Reuses `@module-federation/dts-plugin` standalone.** `DtsPlugin` generates/consumes purely via compiler hooks and is independent of the enhanced container/runtime (enhanced itself applies it as a decoupled plugin). Verified with a real native-container producer→consumer build under **webpack 5.75 and @rspack/core 1.0**.
- **Strict option separation.** `dts` (and `dev`/`runtimePlugins`) are stripped before the native `super(options)` and never enter the banner — the native container and registry runtime are untouched.
- **Ships as an `optionalDependency` + lazy require.** `@module-federation/dts-plugin` installs automatically with the builder (no manual step for consumers), but is `require`d only when `dts` is enabled. It requires Node `>=20.18.1` (via `undici`); on older Node it's skipped at install and enabling `dts` fails with a clear error, so the builder itself stays usable on Node `>=16`.
- **Build-time type-URL discovery.** Since the browser registry doesn't exist at build time, consumer `remoteTypeUrls` are derived from the site config `dependencies`. When `registry` + `registryAutoFetch` are set (fetch type), URLs are resolved from the registry at build time — mirroring the runtime's version resolution (`isSatisfied` gate, consumer version, `registryAutoFetch` condition) — with graceful fallback to static derivation; type resolution never fails the build.
- **SPA builds** skip DTS (following the existing early return).
- **Rspack parity** falls out of the same `DtsPlugin`.

## What's included

- The `dts` option, wiring, and static + registry-aware `remoteTypeUrls` derivation.
- Unit tests (jest) covering option separation, the optional-peer error path, URL derivation edge cases, the registry resolver (version, `isSatisfied` gate, `registryAutoFetch`, fallback), and the SPA gate.
- Docs for the `dts` option.

## What's deferred / offered

- **Real-build fixture harness (Webpack × Rspack).** The current tests are unit-level. I'm happy to contribute a real producer→consumer fixture harness (types-off byte-for-byte, types-on additive, both bundlers) as part of this PR if you'd like it — the repo doesn't have build fixtures today, so it's a meaningful addition worth aligning on first.
- **Dev-time hot type reload** is out of scope for a native container without the enhanced runtime (`dev` is forced off).
- **tsconfig path-alias rewriting**: `dts-plugin` doesn't rewrite path-alias imports in emitted declarations (module-federation/core#3363), so a curated public surface must use relative/package-resolvable imports — documented as a constraint.

## Open questions for maintainers

1. **Contribution process / CLA** — I didn't find a CONTRIBUTING or CLA doc; please point me at the expected process.
2. **`window.__RC_MFE__`** — is the registry runtime a permanent hard requirement, or is there a supported path for natively-built remotes? (Relevant to how far the build-time/runtime type-version alignment can go.)
3. **Packaging preference** — this PR ships `@module-federation/dts-plugin` as an `optionalDependency` (auto-installed, zero manual setup for consumers), at the cost that every builder install pulls it (~a few MB) even when `dts` is unused. If you'd rather keep the builder lean for non-adopters, an optional `peerDependency` (manual install) or a separate companion package are both easy alternatives — your call.

## Testing

`yarn workspace @ringcentral/mfe-builder tsc` clean · `ci:test` green · `build` clean · `prettier -c` clean. Native-container spike built and consumed types under webpack 5.75 and @rspack/core 1.0.
