### PR TITLE
feat(react): support React 18 peer dependency

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -42,10 +42,10 @@
     "@ringcentral/mfe-core": "^0.4.21"
   },
   "devDependencies": {
-    "@testing-library/react": "^12.1.5",
-    "@types/react": "^17.0.52",
+    "@testing-library/react": "^14.3.1",
+    "@types/react": "^18.3.31",
     "jsdoc-tests": "^1.1.1",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -36,7 +36,7 @@
   "author": "RingCentral",
   "license": "MIT",
   "peerDependencies": {
-    "react": "^17.0.2"
+    "react": "^17.0.2 || ^18.0.0"
   },
   "dependencies": {
     "@ringcentral/mfe-core": "^0.4.21"

--- a/packages/react/test/useApp.test.tsx
+++ b/packages/react/test/useApp.test.tsx
@@ -131,13 +131,19 @@ test('check re-render', async () => {
   expect(externalRenderFn).toBeCalledTimes(2);
   expect(internalRenderFn).toBeCalledTimes(1);
 
-  externalUpdate!();
+  // React 18: state updates outside React event handlers are not flushed
+  // synchronously unless wrapped in act().
+  act(() => {
+    externalUpdate!();
+  });
 
   expect(renderFn).toBeCalledTimes(1);
   expect(externalRenderFn).toBeCalledTimes(3);
   expect(internalRenderFn).toBeCalledTimes(1);
 
-  internalUpdate!();
+  act(() => {
+    internalUpdate!();
+  });
 
   expect(renderFn).toBeCalledTimes(1);
   expect(externalRenderFn).toBeCalledTimes(3);

--- a/packages/react/test/useWebComponents.test.tsx
+++ b/packages/react/test/useWebComponents.test.tsx
@@ -130,13 +130,19 @@ test('check re-render', async () => {
   expect(externalRenderFn).toBeCalledTimes(2);
   expect(internalRenderFn).toBeCalledTimes(1);
 
-  externalUpdate!();
+  // React 18: state updates outside React event handlers are not flushed
+  // synchronously unless wrapped in act().
+  act(() => {
+    externalUpdate!();
+  });
 
   expect(renderFn).toBeCalledTimes(1);
   expect(externalRenderFn).toBeCalledTimes(3);
   expect(internalRenderFn).toBeCalledTimes(1);
 
-  internalUpdate!();
+  act(() => {
+    internalUpdate!();
+  });
 
   expect(renderFn).toBeCalledTimes(1);
   expect(externalRenderFn).toBeCalledTimes(3);

--- a/packages/service-worker/package.json
+++ b/packages/service-worker/package.json
@@ -33,11 +33,11 @@
   "license": "MIT",
   "devDependencies": {
     "@rollup/plugin-node-resolve": "15.0.1",
-    "@testing-library/react": "^12.1.5",
-    "@types/react": "^17.0.52",
+    "@testing-library/react": "^14.3.1",
+    "@types/react": "^18.3.31",
     "jest-environment-jsdom": "29.3.1",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "rollup-plugin-dts": "^5.0.0",
     "rollup-plugin-typescript2": "0.34.1",
     "webpack": "^5.75.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1580,10 +1580,10 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@testing-library/dom@^8.0.0":
-  version "8.20.1"
-  resolved "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.1.tgz"
-  integrity sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==
+"@testing-library/dom@^9.0.0":
+  version "9.3.4"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-9.3.4.tgz#50696ec28376926fec0a1bf87d9dbac5e27f60ce"
+  integrity sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/runtime" "^7.12.5"
@@ -1609,14 +1609,14 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
-"@testing-library/react@^12.1.5":
-  version "12.1.5"
-  resolved "https://registry.npmjs.org/@testing-library/react/-/react-12.1.5.tgz"
-  integrity sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==
+"@testing-library/react@^14.3.1":
+  version "14.3.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-14.3.1.tgz#29513fc3770d6fb75245c4e1245c470e4ffdd830"
+  integrity sha512-H99XjUhWQw0lTgyMN05W3xQG1Nh4lq574D8keFf1dDoNTJgp66VbJozRaczoF+wsiaPJNt/TcnfpLGufGxSrZQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@testing-library/dom" "^8.0.0"
-    "@types/react-dom" "<18.0.0"
+    "@testing-library/dom" "^9.0.0"
+    "@types/react-dom" "^18.0.0"
 
 "@tootallnate/once@2":
   version "2.0.0"
@@ -1843,31 +1843,23 @@
   resolved "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz"
   integrity sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==
 
-"@types/react-dom@<18.0.0":
-  version "17.0.25"
-  resolved "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.25.tgz"
-  integrity sha512-urx7A7UxkZQmThYA4So0NelOVjx3V4rNFVJwp0WZlbIK5eM4rNJDiN3R/E9ix0MBh6kAEojk/9YL+Te6D9zHNA==
-  dependencies:
-    "@types/react" "^17"
+"@types/react-dom@^18.0.0":
+  version "18.3.7"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.7.tgz#b89ddf2cd83b4feafcc4e2ea41afdfb95a0d194f"
+  integrity sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==
 
-"@types/react@^17", "@types/react@^17.0.52":
-  version "17.0.75"
-  resolved "https://registry.npmjs.org/@types/react/-/react-17.0.75.tgz"
-  integrity sha512-MSA+NzEzXnQKrqpO63CYqNstFjsESgvJAdAyyJ1n6ZQq/GLgf6nOfIKwk+Twuz0L1N6xPe+qz5xRCJrbhMaLsw==
+"@types/react@^18.3.31":
+  version "18.3.31"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.31.tgz#b5e95e28ffcceab8d982f33f2eb076e17653c2a4"
+  integrity sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==
   dependencies:
     "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
+    csstype "^3.2.2"
 
 "@types/resolve@1.20.2":
   version "1.20.2"
   resolved "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz"
   integrity sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==
-
-"@types/scheduler@*":
-  version "0.16.8"
-  resolved "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz"
-  integrity sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==
 
 "@types/semver@^7.3.12":
   version "7.5.8"
@@ -3543,10 +3535,10 @@ cssstyle@^2.3.0:
   dependencies:
     cssom "~0.3.6"
 
-csstype@^3.0.2:
-  version "3.1.3"
-  resolved "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz"
-  integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
+csstype@^3.2.2:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.2.3.tgz#ec48c0f3e993e50648c86da559e2610995cf989a"
+  integrity sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
 
 cycle@1.0.x:
   version "1.0.3"
@@ -8687,14 +8679,13 @@ randombytes@^2.1.0:
   dependencies:
     safe-buffer "^5.1.0"
 
-react-dom@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz"
-  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
+react-dom@^18.3.1:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.3.1.tgz#c2265d79511b57d479b3dd3fdfa51536494c5cb4"
+  integrity sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    scheduler "^0.20.2"
+    scheduler "^0.23.2"
 
 react-is@^16.13.1:
   version "16.13.1"
@@ -8711,13 +8702,12 @@ react-is@^18.0.0:
   resolved "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
-react@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.npmjs.org/react/-/react-17.0.2.tgz"
-  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+react@^18.3.1:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.3.1.tgz#49ab892009c53933625bd16b2533fc754cab2891"
+  integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 read-cmd-shim@3.0.0:
   version "3.0.0"
@@ -9160,13 +9150,12 @@ saxes@^6.0.0:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@^0.20.2:
-  version "0.20.2"
-  resolved "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz"
-  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
+scheduler@^0.23.2:
+  version "0.23.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.2.tgz#414ba64a3b282892e944cf2108ecc078d115cdc3"
+  integrity sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 schema-utils@^3.1.1, schema-utils@^3.2.0:
   version "3.3.0"


### PR DESCRIPTION
## Summary

`@ringcentral/mfe-react` currently declares `react: ^17.0.2` as its only peer dependency range. Consumers that have upgraded to React 18 get an unmet peer dependency warning on install, even though the package source is hook-only and does not depend on any React-17-specific behavior.

This PR certifies React 18 support:

-   **Widen the peer range** — `react: "^17.0.2 || ^18.0.0"` in `@ringcentral/mfe-react`.
-   **Run the test suites against React 18** — bump `react` / `react-dom` to `^18.3.1`, `@types/react` to `^18.3.31`, and `@testing-library/react` to `^14.3.1` in the dev environments of `packages/react` and `packages/service-worker` (kept in sync to avoid a split hoisted React install).

## Test fixes required by React 18

Two `check re-render` cases (`useApp`, `useWebComponents`) invoked a `setState` callback outside of any React event handler and asserted the re-render synchronously. React 18 no longer flushes such updates synchronously unless wrapped in `act()`. The calls are now wrapped in `act()`; the test intent (MFE render isolation from parent re-renders) is unchanged.

## Intentionally not changed

-   `test/base` fixtures and `examples/*` stay on React 17 with `ReactDOM.render`. Host/remote React version independence is a core MFE guarantee, and keeping the fixtures on 17 preserves the 17-remote vs 18-host interop coverage (see verification below).
-   No source changes in `packages/react/src` — the implementation is hook-only and already compatible.

## Verification

| Check                                        | Result                                             |
| -------------------------------------------- | -------------------------------------------------- |
| `lerna run ci:test` (9 packages)             | ✅ `mfe-react` 20/20                               |
| `lerna run build` (9 packages)               | ✅                                                 |
| `yarn it:test`                               | ✅ React 18 host + React 17 remote fixture interop |
| `yarn e2e:test` (puppeteer)                  | ✅ 8/8                                             |
| `tsc` for `mfe-react` / `mfe-service-worker` | ✅                                                 |
| prettier on touched files                    | ✅                                                 |

Note: the pre-existing `mfe-logger` `tsc` failure (`service-worker/jest.customEnvironment.ts` duplicate identifiers) is unrelated — verified identical with this change stashed.

## Downstream

Once released, React 18 consumers (e.g. the integration-apps monorepo) can bump `@ringcentral/mfe-react` to remove the peer warning. Existing React 17 consumers are unaffected — the peer range still includes `^17.0.2` and no runtime behavior changed.
